### PR TITLE
GitHub workflows

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-format = wemake
+# Brakes GitHub annotations
+; format = wemake
 show-source = True
 
 # See all codes at

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  workflow_call:  # allow this workflow to be called from other workflows
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  build: 
+    name: Frontend and Backend
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: "20.x"
+      YARN_VERSION: "4.0.1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+            node-version: 20.x
+      - name: Set up Yarn
+        run: corepack enable; yarn set version $YARN_VERSION
+      - name: Set up Python
+        # This is the version of the action for setting up Python, not the Python version.
+        uses: actions/setup-python@v5
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x8
+          architecture: 'x64'
+          cache: 'pip' # caching pip dependencies
+      - name: Install dependencies
+        run: python -m pip install .[build] twine
+      - name: Building dist
+        run: python -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Continous Integration
+
+on:
+  workflow_dispatch: # allow manual trigger
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+  test:
+    name: Test
+    uses: ./.github/workflows/test.yml
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  workflow_call:  # allow this workflow to be called from other workflows
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  flake8_py3:
+    name: Flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: TrueBrain/actions-flake8@v2
+        with:
+          only_warn: 1

--- a/.github/workflows/mr.yml
+++ b/.github/workflows/mr.yml
@@ -1,0 +1,15 @@
+name: Merge Checks
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+  test:
+    name: Test
+    uses: ./.github/workflows/test.yml
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  git-tag-check:
+    name: Git Tag Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      # This is the version of the action for setting up Python, not the Python version.
+      uses: actions/setup-python@v5
+      with:
+        # Semantic version range syntax or exact version of a Python version
+        python-version: '3.x'
+        # Optional - x64 or x8
+        architecture: 'x64'
+        cache: 'pip' # caching pip dependencies
+    - name: Install dependencies
+      run: python -m pip install toml
+    - name: Check Git Tag
+      run: |
+        python <<HEREDOC
+        from pathlib import Path
+        import toml
+        import sys
+
+        if '${{ github.ref_type }}' != 'tag':
+          sys.exit(f"Not on a tag")
+        
+        gitversion = '${{ github.ref_name }}'
+        version = "unknown"
+
+        pyproject_toml_file = Path(__file__).parent / "pyproject.toml"
+        if pyproject_toml_file.exists() and pyproject_toml_file.is_file():
+            data = toml.load(pyproject_toml_file)
+            if "project" in data and "version" in data["project"]:
+                version = data["project"]["version"]
+
+        if version != gitversion:
+          sys.exit(f"Git Tag '{gitversion}' doesn't match package version '{version}'")
+        HEREDOC
+
+  test:
+    name: Test
+    needs: [git-tag-check]
+    uses: ./.github/workflows/test.yml
+
+  build:
+    name: Build
+    needs: [test]
+    uses: ./.github/workflows/build.yml  # use the callable tests job to run tests
+
+  github-release:
+    needs: [build]  # require tests to pass before deploy runs
+    name: GitHub Upload
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish to TestPyPi
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/hardpy
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - publish-to-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hardpy
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+on:
+  workflow_call:  # allow this workflow to be called from other workflows
+  workflow_dispatch: # allow manual trigger
+
+permissions:
+  checks: write
+
+jobs:
+  test: 
+    name: PyTest
+    runs-on: ubuntu-latest
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      db:
+        # Docker Hub image
+        image: couchdb:3.3.2
+        env:
+          COUCHDB_USER: dev
+          COUCHDB_PASSWORD: dev         
+        ports:
+          # Maps tcp port 5984 on service container to the host
+          # It is not necessary until use act tool for local gh actions running
+          # The tool doesn't resolve service container by its name,
+          # so pass the connection through the host network
+          - 5984:5984
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      # This is the version of the action for setting up Python, not the Python version.
+      uses: actions/setup-python@v5
+      with:
+        # Semantic version range syntax or exact version of a Python version
+        python-version: '3.x'
+        # Optional - x64 or x8
+        architecture: 'x64'
+        cache: 'pip' # caching pip dependencies
+
+    - name: Install dependencies
+      run: python -m pip install .
+
+    - name: Run PyTest
+      uses: dariocurr/pytest-summary@main
+      env:
+        COUCH_DB_HOST: localhost
+      with:
+        options: --hardpy-dbh ${COUCH_DB_HOST} tests
+        show: "all"


### PR DESCRIPTION
The MR adds workflows for
- Merge Requests
- Releases
- Main branch continuous integration 

All of them are combinations of auxiliary workflows:
- Lint (flake8)
- Test (pytest)
- Build

Release workflow in addition include deployment jobs:
- GitHub
- TestPyPi
- PyPi

The release also includes protecting check that prevent deploy python package with non-matching git tag.

A workflow that includes Lint and Test stages shows in its summary page the result of runs: list of warnings, errors, and test results table. In addition, Merge Requests in the file diffs page shows annotations generated by the Lint stage.

Flake8 config wile has a change that disable explicit format set to 'wemake'. For some reason, it breaks GitHub annotations.