### PR TITLE
Add build MkDocs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,19 @@
+name: Docs
+
+on:
+  workflow_dispatch: # allow manual trigger
+  push:
+    branches:
+      - main
+
+jobs:
+  docs: 
+    name: Build MkDocs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIREMENTS: requirements-doc.txt


### PR DESCRIPTION
This GitHub workflow builds docs and creates `gh-pages` branch for deployment to Pages.

Be sure settings for GitHub Pages set the correct branch.

Generated [docs preview](https://ila-embsys.github.io/hardpy/) was tested on my fork.