### PR TITLE
Speed up test collection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Reduce the number of database calls.
+* Speed up test collection.
+
 ## HardPy 0.2.0
 
 * Add documentation site.

--- a/hardpy/pytest_hardpy/db/base_store.py
+++ b/hardpy/pytest_hardpy/db/base_store.py
@@ -37,37 +37,28 @@ class BaseStore(BaseConnector):
         return glom(self._doc, key)
 
     def update_doc(self, key: str, value):
-        """Update document in the database.
+        """Update document.
 
-        Update document without database by key and value.
+        HardPy collecting uses a simple key without dots.
+        Assign is used to update a document.
+        Assign is a longer function.
+
+        Args:
+            key (str): document key
+            value: document value
         """
-        assign(self._doc, key, value)
+        if "." in key:
+            assign(self._doc, key, value)
+        else:
+            self._doc[key] = value
 
     def update_db(self):
         """Update database by current document."""
         try:
             self._doc = self._db.save(self._doc)
-        except Conflict as exc:
-            self._log.error(
-                f"Error while saving runner document: {exc} "
-                "Current document will be changed by "
-                "document from database."
-            )
-            self._doc = self._db.get(self._doc_id)
-
-    def set_value(self, key: str, value):
-        """Set a value in the database."""
-        assign(self._doc, key, value)
-        try:
+        except Conflict:
+            self._doc["_rev"] = self._db.get(self._doc_id)["_rev"]
             self._doc = self._db.save(self._doc)
-        except Conflict as exc:
-            self._log.error(
-                f"Error while saving runner document: {exc} "
-                f"when trying to save key={key}, value={value}. "
-                "Current document will be changed by "
-                "document from database."
-            )
-            self._doc = self._db.get(self._doc_id)
 
     def get_document(self) -> ModelMetaclass:
         """Get document by schema.

--- a/hardpy/pytest_hardpy/db/base_store.py
+++ b/hardpy/pytest_hardpy/db/base_store.py
@@ -36,8 +36,27 @@ class BaseStore(BaseConnector):
         """
         return glom(self._doc, key)
 
+    def update_doc(self, key: str, value):
+        """Update document in the database.
+
+        Update document without database by key and value.
+        """
+        assign(self._doc, key, value)
+
+    def update_db(self):
+        """Update database by current document."""
+        try:
+            self._doc = self._db.save(self._doc)
+        except Conflict as exc:
+            self._log.error(
+                f"Error while saving runner document: {exc} "
+                "Current document will be changed by "
+                "document from database."
+            )
+            self._doc = self._db.get(self._doc_id)
+
     def set_value(self, key: str, value):
-        """Set a value in the state store."""
+        """Set a value in the database."""
         assign(self._doc, key, value)
         try:
             self._doc = self._db.save(self._doc)

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -107,6 +107,7 @@ class HardpyPlugin(object):
         self._reporter.init_doc(str(PurePath(config.rootpath).name))
 
         nodes = {}
+        modules = set()
 
         session.items = natsorted(
             session.items,
@@ -125,7 +126,10 @@ class HardpyPlugin(object):
                 nodes[node_info.module_id].append(node_info.case_id)
 
             self._reporter.add_case(node_info)
-            self._reporter.set_module_status(node_info.module_id, TestStatus.READY)
+            modules.add(node_info.module_id)
+        self._reporter.update_database()
+        for module_id in modules:
+            self._reporter.set_module_status(module_id, TestStatus.READY)
         self._reporter.update_node_order(nodes)
 
     # Test running (runtest) hooks

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -40,6 +40,7 @@ def pytest_addoption(parser: Parser):
     parser.addoption("--hardpy-pt", action="store_true", default=False, help="enable pytest-hardpy plugin")  # noqa: E501
     # fmt: on
 
+
 # Bootstrapping hooks
 def pytest_load_initial_conftests(early_config, parser, args):
     if "--hardpy-pt" in args:
@@ -63,7 +64,6 @@ class HardpyPlugin(object):
         elif system() == "Windows":
             signal.signal(signal.SIGBREAK, self._stop_handler)
         self._log = getLogger(__name__)
-
 
     # Initialization hooks
 
@@ -92,6 +92,8 @@ class HardpyPlugin(object):
             return
         status = self._get_run_status(exitstatus)
         self._reporter.finish(status)
+        self._reporter.update_db_by_doc()
+        self._reporter.compact_all()
 
         # call post run methods
         if self._post_run_functions:
@@ -119,7 +121,6 @@ class HardpyPlugin(object):
             node_info = NodeInfo(item)
 
             self._init_case_result(node_info.module_id, node_info.case_id)
-
             if node_info.module_id not in nodes:
                 nodes[node_info.module_id] = [node_info.case_id]
             else:
@@ -127,10 +128,10 @@ class HardpyPlugin(object):
 
             self._reporter.add_case(node_info)
             modules.add(node_info.module_id)
-        self._reporter.update_database()
         for module_id in modules:
             self._reporter.set_module_status(module_id, TestStatus.READY)
         self._reporter.update_node_order(nodes)
+        self._reporter.update_db_by_doc()
 
     # Test running (runtest) hooks
 
@@ -143,6 +144,7 @@ class HardpyPlugin(object):
 
         # testrun entrypoint
         self._reporter.start()
+        self._reporter.update_db_by_doc()
 
     def pytest_runtest_setup(self, item: Item):
         """Call before each test setup phase."""
@@ -163,6 +165,7 @@ class HardpyPlugin(object):
             node_info.module_id,
             node_info.case_id,
         )
+        self._reporter.update_db_by_doc()
 
     # Reporting hooks
 
@@ -192,6 +195,7 @@ class HardpyPlugin(object):
 
         if None not in self._results[module_id].values():
             self._collect_module_result(module_id)
+        self._reporter.update_db_by_doc()
 
     # Fixture
 

--- a/hardpy/pytest_hardpy/pytest_call.py
+++ b/hardpy/pytest_hardpy/pytest_call.py
@@ -52,7 +52,8 @@ def set_dut_info(info: dict):
     reporter = RunnerReporter()
     for dut_key, dut_value in info.items():
         key = reporter.generate_key(DF.DUT, DF.INFO, dut_key)
-        reporter.set_db_value(key, dut_value)
+        reporter.set_doc_value(key, dut_value)
+    reporter.update_db_by_doc()
 
 
 def set_dut_serial_number(serial_number: str):
@@ -68,7 +69,8 @@ def set_dut_serial_number(serial_number: str):
     key = reporter.generate_key(DF.DUT, DF.SERIAL_NUMBER)
     if reporter.get_field(key):
         raise DuplicateSerialNumberError
-    reporter.set_db_value(key, serial_number)
+    reporter.set_doc_value(key, serial_number)
+    reporter.update_db_by_doc()
 
 
 def set_stand_info(info: dict):
@@ -80,7 +82,8 @@ def set_stand_info(info: dict):
     reporter = RunnerReporter()
     for stand_key, stand_value in info.items():
         key = reporter.generate_key(DF.TEST_STAND, stand_key)
-        reporter.set_db_value(key, stand_value)
+        reporter.set_doc_value(key, stand_value)
+    reporter.update_db_by_doc()
 
 
 def set_message(msg: str, msg_key: Optional[str] = None) -> None:
@@ -111,7 +114,8 @@ def set_message(msg: str, msg_key: Optional[str] = None) -> None:
 
     msgs[msg_key] = msg
 
-    reporter.set_db_value(key, msgs)
+    reporter.set_doc_value(key, msgs)
+    reporter.update_db_by_doc()
 
 
 def set_case_artifact(data: dict):
@@ -134,7 +138,8 @@ def set_case_artifact(data: dict):
             DF.ARTIFACT,
             stand_key,
         )
-        reporter.set_db_value(key, stand_value, is_statestore=False)
+        reporter.set_doc_value(key, stand_value, runstore_only=True)
+    reporter.update_db_by_doc()
 
 
 def set_module_artifact(data: dict):
@@ -155,7 +160,8 @@ def set_module_artifact(data: dict):
             DF.ARTIFACT,
             artifact_key,
         )
-        reporter.set_db_value(key, artifact_value, is_statestore=False)
+        reporter.set_doc_value(key, artifact_value, runstore_only=True)
+    reporter.update_db_by_doc()
 
 
 def set_run_artifact(data: dict):
@@ -173,7 +179,8 @@ def set_run_artifact(data: dict):
             DF.ARTIFACT,
             artifact_key,
         )
-        reporter.set_db_value(key, artifact_value, is_statestore=False)
+        reporter.set_doc_value(key, artifact_value, runstore_only=True)
+    reporter.update_db_by_doc()
 
 
 def set_driver_info(drivers: dict) -> None:
@@ -192,7 +199,8 @@ def set_driver_info(drivers: dict) -> None:
             DF.DRIVERS,
             driver_name,
         )
-        reporter.set_db_value(key, driver_data)
+        reporter.set_doc_value(key, driver_data)
+    reporter.update_db_by_doc()
 
 
 def _get_current_test() -> CurrentTestInfo:

--- a/hardpy/pytest_hardpy/reporter/base.py
+++ b/hardpy/pytest_hardpy/reporter/base.py
@@ -14,12 +14,35 @@ class BaseReporter(object):
         self._runstore = RunStore()
         self._log = getLogger(__name__)
 
+    def update_doc(self, key: str, value, is_statestore=True, is_runstore=True):
+        """Update document in the database.
+
+        Update document without database by key and value.
+
+        Args:
+            key (str): document key
+            value: document value
+            is_statestore (bool, optional): indicates whether data should
+                                             be written to StateStore. Defaults to True.
+            is_runstore (bool, optional): indicates whether data should
+                                            be written to RunStore. Defaults to True.
+        """
+        if is_statestore:
+            self._statestore.update_doc(key, value)
+        if is_runstore:
+            self._runstore.update_doc(key, value)
+
+    def update_db(self):
+        """Update database by current document."""
+        self._statestore.update_db()
+        self._runstore.update_db()
+
     def set_db_value(self, key: str, value, is_statestore=True, is_runstore=True):
         """Set value to database.
 
         Args:
             key (str): database key
-            value (_type_): database value
+            value: database value
             is_statestore (bool, optional): indicates whether data should
                                              be written to StateStore. Defaults to True.
             is_runstore (bool, optional): indicates whether data should

--- a/hardpy/pytest_hardpy/reporter/base.py
+++ b/hardpy/pytest_hardpy/reporter/base.py
@@ -14,44 +14,39 @@ class BaseReporter(object):
         self._runstore = RunStore()
         self._log = getLogger(__name__)
 
-    def update_doc(self, key: str, value, is_statestore=True, is_runstore=True):
-        """Update document in the database.
+    def set_doc_value(
+        self, key: str, value, runstore_only=False, statestore_only=False
+    ):
+        """Set value to the document.
 
-        Update document without database by key and value.
+        Update a document without writing to the database.
 
         Args:
             key (str): document key
             value: document value
-            is_statestore (bool, optional): indicates whether data should
-                                             be written to StateStore. Defaults to True.
-            is_runstore (bool, optional): indicates whether data should
-                                            be written to RunStore. Defaults to True.
-        """
-        if is_statestore:
-            self._statestore.update_doc(key, value)
-        if is_runstore:
-            self._runstore.update_doc(key, value)
+            runstore_only (bool, optional): indicates whether data should
+                                             be written to RunStore. Defaults to True.
+            statestore_only (bool, optional): indicates whether data should
+                                            be written to StateStore. Defaults to True.
 
-    def update_db(self):
+        Raises:
+            ValueError: if both runstore_only and statestore_only are True
+        """
+        if runstore_only and statestore_only:
+            raise ValueError("Both runstore_only and statestore_only cannot be True")
+        if runstore_only:
+            self._runstore.update_doc(key, value)
+            return
+        if statestore_only:
+            self._statestore.update_doc(key, value)
+            return
+        self._runstore.update_doc(key, value)
+        self._statestore.update_doc(key, value)
+
+    def update_db_by_doc(self):
         """Update database by current document."""
         self._statestore.update_db()
         self._runstore.update_db()
-
-    def set_db_value(self, key: str, value, is_statestore=True, is_runstore=True):
-        """Set value to database.
-
-        Args:
-            key (str): database key
-            value: database value
-            is_statestore (bool, optional): indicates whether data should
-                                             be written to StateStore. Defaults to True.
-            is_runstore (bool, optional): indicates whether data should
-                                            be written to RunStore. Defaults to True.
-        """
-        if is_statestore:
-            self._statestore.set_value(key, value)
-        if is_runstore:
-            self._runstore.set_value(key, value)
 
     def generate_key(self, *args) -> str:
         """Generate key for database.

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -100,8 +100,8 @@ class HookReporter(BaseReporter):
             is_use_artifact=True,
         )
 
-        self.set_db_value(key, new_item_statestore, is_runstore=False)
-        self.set_db_value(key, new_item_runstore, is_statestore=False)
+        self.update_doc(key, new_item_statestore, is_runstore=False)
+        self.update_doc(key, new_item_runstore, is_statestore=False)
 
     def set_case_status(self, module_id: str, case_id: str, status: TestStatus):
         """Set test case status.
@@ -176,6 +176,10 @@ class HookReporter(BaseReporter):
         updated_case_order = self._update_case_order(rm_outdated_nodes, nodes)
         updated_module_order = self._update_module_order(updated_case_order)
         self.set_db_value(key, updated_module_order, is_runstore=False)
+
+    def update_database(self):
+        """Update database."""
+        self.update_db()
 
     def _set_time(self, key: str):
         current_time = self._statestore.get_field(key)

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -25,23 +25,23 @@ class HookReporter(BaseReporter):
         Args:
             doc_name (str): test run name
         """
-        self.set_db_value(DF.NAME, doc_name)
-        self.set_db_value(DF.STATUS, TestStatus.READY)
-        self.set_db_value(DF.START_TIME, None)
-        self.set_db_value(DF.TIMEZONE, None)
-        self.set_db_value(DF.STOP_TIME, None)
-        self.set_db_value(DF.PROGRESS, 0)
-        self.set_db_value(DF.DRIVERS, {})
-        self.set_db_value(DF.ARTIFACT, {}, is_statestore=False)
+        self.set_doc_value(DF.NAME, doc_name)
+        self.set_doc_value(DF.STATUS, TestStatus.READY)
+        self.set_doc_value(DF.START_TIME, None)
+        self.set_doc_value(DF.TIMEZONE, None)
+        self.set_doc_value(DF.STOP_TIME, None)
+        self.set_doc_value(DF.PROGRESS, 0)
+        self.set_doc_value(DF.DRIVERS, {})
+        self.set_doc_value(DF.ARTIFACT, {}, runstore_only=True)
 
     def start(self):
         """Start test."""
         self._log.debug("Starting test run.")
         start_time = int(time())
-        self.set_db_value(DF.START_TIME, start_time)
-        self.set_db_value(DF.STATUS, TestStatus.RUN)
-        self.set_db_value(DF.TIMEZONE, tzname)  # noqa: WPS432
-        self.set_db_value(DF.PROGRESS, 0)
+        self.set_doc_value(DF.START_TIME, start_time)
+        self.set_doc_value(DF.STATUS, TestStatus.RUN)
+        self.set_doc_value(DF.TIMEZONE, tzname)  # noqa: WPS432
+        self.set_doc_value(DF.PROGRESS, 0)
 
     def finish(self, status: RunStatus):
         """Finish test.
@@ -50,15 +50,11 @@ class HookReporter(BaseReporter):
         """
         self._log.debug("Finishing test run.")
         stop_time = int(time())
-        self.set_db_value(DF.STOP_TIME, stop_time)
-        self.set_db_value(DF.STATUS, status)
+        self.set_doc_value(DF.STOP_TIME, stop_time)
+        self.set_doc_value(DF.STATUS, status)
 
-        if self._statestore.get_document():
-            self._log.debug("Report StateStore has been successfully validated.")
-
-        if self._runstore.get_document():
-            self._log.debug("Report RunStore has been successfully validated.")
-
+    def compact_all(self):
+        """Compact all databases"""
         self._statestore.compact()
         self._runstore.compact()
 
@@ -68,7 +64,7 @@ class HookReporter(BaseReporter):
         Args:
             progress (int): test progress
         """
-        self.set_db_value(DF.PROGRESS, progress)
+        self.set_doc_value(DF.PROGRESS, progress)
 
     def set_assertion_msg(self, module_id: str, case_id: str, msg: str | None):
         """Set case assertion message.
@@ -81,7 +77,7 @@ class HookReporter(BaseReporter):
         key = self.generate_key(
             DF.MODULES, module_id, DF.CASES, case_id, DF.ASSERTION_MSG
         )
-        self.set_db_value(key, msg)
+        self.set_doc_value(key, msg)
 
     def add_case(self, node_info: NodeInfo):
         """Add test case to document.
@@ -90,18 +86,15 @@ class HookReporter(BaseReporter):
             node_info (NodeInfo): node info
         """
         key = DF.MODULES
+
         item_statestore = self._statestore.get_field(key)
         item_runstore = self._runstore.get_field(key)
 
-        new_item_statestore = self._init_case(item_statestore, node_info)
-        new_item_runstore = self._init_case(
-            item_runstore,
-            node_info,
-            is_use_artifact=True,
-        )
+        self._init_case(item_statestore, node_info)
+        self._init_case(item_runstore, node_info, is_use_artifact=True)
 
-        self.update_doc(key, new_item_statestore, is_runstore=False)
-        self.update_doc(key, new_item_runstore, is_statestore=False)
+        self.set_doc_value(key, item_statestore, statestore_only=True)
+        self.set_doc_value(key, item_runstore, runstore_only=True)
 
     def set_case_status(self, module_id: str, case_id: str, status: TestStatus):
         """Set test case status.
@@ -112,7 +105,7 @@ class HookReporter(BaseReporter):
             status (TestStatus): test case status
         """
         key = self.generate_key(DF.MODULES, module_id, DF.CASES, case_id, DF.STATUS)
-        self.set_db_value(key, status)
+        self.set_doc_value(key, status)
 
     def set_case_start_time(self, module_id: str, case_id: str):
         """Set test case start_time.
@@ -142,7 +135,7 @@ class HookReporter(BaseReporter):
             status (TestStatus): test module status
         """
         key = self.generate_key(DF.MODULES, module_id, DF.STATUS)
-        self.set_db_value(key, status)
+        self.set_doc_value(key, status)
 
     def set_module_start_time(self, module_id: str):
         """Set test module status.
@@ -175,20 +168,16 @@ class HookReporter(BaseReporter):
         rm_outdated_nodes = self._remove_outdate_node(old_modules, modules_copy, nodes)
         updated_case_order = self._update_case_order(rm_outdated_nodes, nodes)
         updated_module_order = self._update_module_order(updated_case_order)
-        self.set_db_value(key, updated_module_order, is_runstore=False)
-
-    def update_database(self):
-        """Update database."""
-        self.update_db()
+        self.set_doc_value(key, updated_module_order, statestore_only=True)
 
     def _set_time(self, key: str):
         current_time = self._statestore.get_field(key)
         if current_time is None:
-            self.set_db_value(key, int(time()))
+            self.set_doc_value(key, int(time()))
 
     def _init_case(
         self, item: dict, node_info: NodeInfo, is_use_artifact: bool = False
-    ) -> dict:
+    ):
         module_default = {  # noqa: WPS204
             DF.STATUS: TestStatus.READY,
             DF.NAME: self._get_module_name(node_info),
@@ -219,8 +208,6 @@ class HookReporter(BaseReporter):
         if is_use_artifact:
             case_default[DF.ARTIFACT] = {}
         item[node_info.module_id][DF.CASES][node_info.case_id] = case_default
-
-        return item
 
     def _remove_outdate_node(
         self, old_modules: dict, new_modules: dict, nodes: dict


### PR DESCRIPTION
* Accelerated collection of tests. When tests collected, `glom.assign` is replaced by the default dict call. `glom.assign` is too longer function for collection.

```python
def update_doc(self, key: str, value):
    if "." in key:
        assign(self._doc, key, value)
    else:
        self._doc[key] = value
```

* Reduced the number of database calls. Database update is now a separate function `update_db_by_doc()`.
* Added correct handling of pycouchdb exception `Conflict` in `update_db` method.
* Refactored some function names and their logic.