### PR TITLE
Repository links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,13 @@
+# Project information
 site_name: HardPy
+site_url: https://everypinio.github.io/hardpy/
+site_author: Everypin
 site_dir: public
 docs_dir: ./docs
+
+# Repository
+repo_name: everypinio/hardpy
+repo_url: https://github.com/everypinio/hardpy
 
 theme:
   name: material


### PR DESCRIPTION
Added links to the repository to the header of the documentation site.

It was:
![image](https://github.com/everypinio/hardpy/assets/163293136/a7d86e40-60d0-4467-beb9-c095afe9a548)

It became: 
![image](https://github.com/everypinio/hardpy/assets/163293136/07e6d36f-90b2-467b-ba22-60dbebfc4422)
