### PR TITLE
Update gh-action-sigstore-python up to 2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
The update helps with the latest [build error.](https://github.com/everypinio/hardpy/actions/runs/9417907338/job/25944241346)