### PR TITLE
Remove ansi codes from frontend

### DIFF
--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -195,8 +195,9 @@ class HardpyPlugin(object):
 
     def pytest_runtest_logreport(self, report: TestReport):
         """Call after call of each test item."""
-        if report.when != "call":
+        if report.when != "call" and report.failed is False:
             # ignore setup and teardown phase
+            # or continue processing setup and teardown failure (fixture exception handler)
             return True
 
         module_id = Path(report.fspath).stem

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from logging import getLogger
 from pathlib import Path, PurePath
 from platform import system
+from re import compile as re_compile
 
 from natsort import natsorted
 from pytest import (
@@ -299,7 +300,11 @@ class HardpyPlugin(object):
                 if isinstance(error, ExceptionRepr) and isinstance(  # noqa: WPS337
                     error.reprcrash, ReprFileLocation
                 ):
-                    return error.reprcrash.message
+                    # remove ansi codes
+                    ansi_pattern = re_compile(
+                        r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])"  # noqa: E501
+                    )
+                    return ansi_pattern.sub("", error.reprcrash.message)
                 return str(error)
             case _:
                 return None


### PR DESCRIPTION
1. Removed ANSI codes from frontend. Fix problem with ANSI codes in pytest terminal output in operator panel (image).
![image](https://github.com/user-attachments/assets/70872efd-fcb4-4de5-8583-73e7a4b0997c)
2. Added an exception handler for an exception in the pytest fixture, like DriverExample in the minute parity example.