### PR TITLE
Fix some documentation details

### DIFF
--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -93,8 +93,9 @@ python -m build
 
 1. Install dependencies or create environment.
 2. Compile frontend if it's the first launch.
-3. Launch **CouchDB** instance.
-4. Launch `hardpy-panel` with path to tests folder.
+3. Launch `hardpy init` with path to tests folder.
+4. Launch **CouchDB** instance.
+5. Launch `hardpy run` with path to tests folder.
 
 Addresses:
 

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -22,7 +22,7 @@ Another way to enable a plugin without `pytest.ini` file is to run tests with th
 pytest --hardpy-pt tests
 ```
 
-If tests are run via [hardpy-panel](hardpy_panel.md), then the pytest-hardpy plugin will be enabled for tests by default.
+If tests are run via [hardpy panel](hardpy_panel.md), then the pytest-hardpy plugin will be enabled for tests by default.
 
 ## Functions
 

--- a/docs/examples/multiple_stands.md
+++ b/docs/examples/multiple_stands.md
@@ -9,7 +9,7 @@ assigned to it in the **runstore** and **statestore** databases.
 The third CouchDB Instance is needed to store reports in the **report**
 database on each conducted test of each stand.
 
-You can learn more about storing reports here 
+You can learn more about storing reports here
 [Couchdb instance](../documentation/database.md#couchdb-instance).
 
 ### projects
@@ -21,13 +21,13 @@ hardpy init tests_1
 ```
 
 ```bash
-hardpy init tests_2 --database-port 5985 --frontend-port 8001 
+hardpy init tests_2 --database-port 5985 --frontend-port 8001
 ```
 
 ### databases
 
-For the third database, you can use `hardpy init` and delete 
-all files except the database folder and the `docker-compose.yaml` file. 
+For the third database, you can use `hardpy init` and delete
+all files except the database folder and the `docker-compose.yaml` file.
 
 ```bash
 hardpy init third_database --database-port 5986
@@ -82,5 +82,5 @@ hardpy init tests_2 --database-port 5985 --frontend-port 8001 --socket-port 6526
 
 ### how to start
 
-1. Start all databases via `docker compose`.
-2. Launch both project via `hardpy run <project_name>`
+1. Start all databases via **docker compose**.
+2. Launch both project via `hardpy run <project_name>`.

--- a/docs/examples/operator_msg.md
+++ b/docs/examples/operator_msg.md
@@ -1,8 +1,8 @@
 # Operator message
 
-The [set_operator_message](./../documentation/pytest_hardpy.md/#set_operator_message) 
+The [set_operator_message](./../documentation/pytest_hardpy.md/#set_operator_message)
 function is intended for sending messages to the operator.
-Operator messages are required to promptly inform the operator of 
+Operator messages are required to promptly inform the operator of
 problems if they occur before the test begins or after the test is completed.
 
 ![operator_msg](../img/operator_msg.png)
@@ -11,18 +11,18 @@ problems if they occur before the test begins or after the test is completed.
 
 1. Launch [CouchDH instance](../documentation/database.md#couchdb-instance).
 2. Create a directory `<dir_name>` with the files described below.
-3. Launch `hardpy-panel <dir_name>`.
+3. Launch `hardpy run <dir_name>`.
 
 ### description
 
-The `set_operator_message()` function is used to send a message to the operator, 
-which is stored in the **statestore** database. 
-This function is primarily intended for events that occur outside of the testing environment. 
+The `set_operator_message()` function is used to send a message to the operator,
+which is stored in the **statestore** database.
+This function is primarily intended for events that occur outside of the testing environment.
 For messages during testing, please use the [run_dialog_box](./../documentation/pytest_hardpy.md/#run_dialog_box) function.
 
 To use:
 
-Call method `set_operator_message()` if you want a message to appear in 
+Call method `set_operator_message()` if you want a message to appear in
 the operator panel for the operator when the condition you specify is met.
 
 
@@ -38,4 +38,3 @@ def my_function():
     except Exception as e:
         hardpy.set_operator_message(msg=str(e), title="Important Notice")
 ```
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,6 @@
     <img src="https://everypinio.github.io/hardpy/img/logo256.png" alt="HardPy" style="width:200px;">
 </h1>
 
-<h1 align="center">
-    <b>HardPy</b>
-</h1>
-
 <p align="center">
 HardPy is a python library for creating a test bench for devices.
 </p>


### PR DESCRIPTION
1. Removed the name **HardPy** from the index page.
2. Replaced `hardpy-panel` with `hardpy init` or `hardpy run` commands.
3. Changed some minor details.