### PR TITLE
Fix the structure image

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ hardpy run
 
 ## Examples
 
-Find more examples of using the **HardPy** in the [examples](https://github.com/everypinio/hardpy/tree/main/examples) folder.
+For more examples of using **HardPy**, see the [examples](https://github.com/everypinio/hardpy/tree/main/examples) folder and the [documentation](https://everypinio.github.io/hardpy/examples/).

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -47,6 +47,6 @@ For more info, read [database](./database.md).
 <figure align="left" width="800">
     <img src="https://raw.githubusercontent.com/everypinio/hardpy/main/docs/img/hardpy_struct.drawio.png" alt="hardpy structure">
     <figcaption align="center">
-        Hardpy structure
+        HardPy structure
     </figcaption>
 </figure>

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -12,7 +12,7 @@
 
 For more info, read [CLI](./cli.md).
 
-## HardPy pytest plugin 
+## HardPy pytest plugin
 
 **pytest-hardpy** on a [structural scheme](#structural-scheme).
 
@@ -45,7 +45,7 @@ For more info, read [database](./database.md).
 ## Structural scheme
 
 <figure align="left" width="800">
-    <img src="../img/hardpy_struct.drawio.png" alt="hardpy_structure">
+    <img src="https://raw.githubusercontent.com/everypinio/hardpy/main/docs/img/hardpy_struct.drawio.png" alt="hardpy structure">
     <figcaption align="center">
         Hardpy structure
     </figcaption>

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,5 @@
+# Examples
+
+HardPy includes working examples directly in the package in
+the [examples](https://github.com/everypinio/hardpy/tree/main/examples) folder.
+However, the documentation contains more examples, which you can explore in this section.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,13 +46,14 @@ nav:
   - HardPy: index.md
   - Features: features/features.md
   - Documentation:
-      - Structure: documentation/structure.md
+      - documentation/index.md
       - CLI: documentation/cli.md
       - Configuration: documentation/hardpy_config.md
       - Database: documentation/database.md
       - Pytest-hardpy: documentation/pytest_hardpy.md
       - HardPy panel: documentation/hardpy_panel.md
   - Examples:
+      - examples/index.md
       - Hello HardPy: examples/hello_hardpy.md
       - CouchDB load: examples/couchdb_load.md
       - Minute parity: examples/minute_parity.md


### PR DESCRIPTION
* Fix the structure image path.
* Add `index.md` for **documentation** and **examples** sections.