### PR TITLE
Fix skipped test case and module status

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Fix skipped test case and module status. Now status of skipped test is **skipped**, not **ready**.
+
 ## HardPy 0.7.0
 
 * Add an **attempt** marker to indicate the number of attempts to run a test before it passes successfully.


### PR DESCRIPTION
Fix skipped test case and module status. Now status of skipped test is **skipped**, not **ready**.

Problem artifact:

```json
{
    "_id": "current",
    "_rev": "2829-d2674ae2a652c10fdd530edef3fc38e7",
    "modules": {
        "test_2": {
            "status": "failed",
            "name": "Main tests",
            "start_time": 1730357474,
            "stop_time": 1730357474,
            "cases": {
                "test_minute_parity": {
                    "status": "failed",
                    "name": "Minute check",
                    "start_time": 1730357474,
                    "stop_time": 1730357474,
                    "assertion_msg": "AssertionError: The test failed because 51 is odd! Try again!\nassert 1 == 0",
                    "msg": {
                        "d5df6710-2d30-4061-93b8-8bc2b3389d27": "Current minute 51"
                    },
                    "artifact": {
                        "minute": 51
                    }
                }
            },
            "artifact": {}
        },
        "test_3": {
            "status": "ready",
            "name": "End of testing",
            "start_time": null,
            "stop_time": null,
            "cases": {
                "test_one": {
                    "status": "ready",
                    "name": "Final case",
                    "start_time": null,
                    "stop_time": null,
                    "assertion_msg": null,
                    "msg": null,
                    "artifact": {}
                }
            },
            "artifact": {}
        }
    },
    "name": "minute_parity",
    "status": "failed",
    "start_time": 1730357474,
    "stop_time": 1730357474,
    "artifact": {}
}
```

Correct artifact:

```json
{
  "_id": "current",
  "_rev": "983-3efabb7e4fd74e008e8bef1662167e9c",
  "modules": {
    "test_2": {
      "status": "failed",
      "name": "Main tests",
      "start_time": 1730548746,
      "stop_time": 1730548746,
      "cases": {
        "test_minute_parity": {
          "status": "failed",
          "name": "Minute check",
          "start_time": 1730548746,
          "stop_time": 1730548746,
          "assertion_msg": "AssertionError: The test failed because 59 is odd! Try again!\nassert 1 == 0",
          "msg": {
            "a7d8db6d-989c-40a1-9d9b-136e2385c608": "Current minute 59"
          },
          "dialog_box": {},
          "attempt": 1
        }
      }
    },
    "test_3": {
      "status": "skipped",
      "name": "End of testing",
      "start_time": 1730548746,
      "stop_time": null,
      "cases": {
        "test_one": {
          "status": "skipped",
          "name": "Final case",
          "start_time": null,
          "stop_time": null,
          "assertion_msg": null,
          "msg": null,
          "dialog_box": {},
          "attempt": 0
        }
      }
    }
  },
  "name": "minute_parity",
  "status": "failed",
  "start_time": 1730548745,
  "stop_time": 1730548746,
}
```