### PR TITLE
Fix timezone format

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Fix the timezone format via the **tzlocal** package.
 * Fix skipped test case and module status. Now status of skipped test is **skipped**, not **ready**.
 
 ## HardPy 0.7.0

--- a/docs/documentation/database.md
+++ b/docs/documentation/database.md
@@ -277,7 +277,7 @@ Example of a **current** document:
         "info": {
           "geo": "Belgrade"
         },
-        "timezone": "CET",
+        "timezone": "Europe/Belgrade",
         "drivers": {
           "driver_1": "driver info",
           "driver_2": {
@@ -414,7 +414,7 @@ Example of a **current** document:
         "info": {
           "geo": "Belgrade"
         },
-        "timezone": "CET",
+        "timezone": "Europe/Belgrade",
         "drivers": {
           "driver_1": "driver info",
           "driver_2": {

--- a/hardpy/pytest_hardpy/db/schema/v1.py
+++ b/hardpy/pytest_hardpy/db/schema/v1.py
@@ -177,7 +177,7 @@ class TestStand(BaseModel):
         "info": {
           "geo": "Belgrade"
         },
-        "timezone": "CET",
+        "timezone": "Europe/Belgrade",
         "drivers": {
           "driver_1": "driver info",
           "driver_2": {
@@ -228,7 +228,7 @@ class ResultStateStore(IBaseResult):
         "info": {
           "geo": "Belgrade"
         },
-        "timezone": "CET",
+        "timezone": "Europe/Belgrade",
         "drivers": {
           "driver_1": "driver info",
           "driver_2": {
@@ -324,7 +324,7 @@ class ResultRunStore(IBaseResult):
         "info": {
           "geo": "Belgrade"
         },
-        "timezone": "CET",
+        "timezone": "Europe/Belgrade",
         "drivers": {
           "driver_1": "driver info",
           "driver_2": {

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime
 from logging import getLogger
 from time import time
 
 from natsort import natsorted
+from tzlocal import get_localzone_name
 
 from hardpy.pytest_hardpy.db import DatabaseField as DF  # noqa: N817
 from hardpy.pytest_hardpy.reporter.base import BaseReporter
@@ -38,7 +38,7 @@ class HookReporter(BaseReporter):
         self.set_doc_value(DF.OPERATOR_MSG, {}, statestore_only=True)
 
         test_stand_tz = self.generate_key(DF.TEST_STAND, DF.TIMEZONE)
-        self.set_doc_value(test_stand_tz, datetime.now().astimezone().tzname())
+        self.set_doc_value(test_stand_tz, get_localzone_name())
 
         test_stand_id_key = self.generate_key(DF.TEST_STAND, DF.HW_ID)
         self.set_doc_value(test_stand_id_key, machine_id())

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from time import time
 
 from natsort import natsorted
-from tzlocal import get_localzone_name
+from tzlocal import get_localzone
 
 from hardpy.pytest_hardpy.db import DatabaseField as DF  # noqa: N817
 from hardpy.pytest_hardpy.reporter.base import BaseReporter
@@ -38,7 +38,7 @@ class HookReporter(BaseReporter):
         self.set_doc_value(DF.OPERATOR_MSG, {}, statestore_only=True)
 
         test_stand_tz = self.generate_key(DF.TEST_STAND, DF.TIMEZONE)
-        self.set_doc_value(test_stand_tz, get_localzone_name())
+        self.set_doc_value(test_stand_tz, str(get_localzone().key))
 
         test_stand_id_key = self.generate_key(DF.TEST_STAND, DF.HW_ID)
         self.set_doc_value(test_stand_id_key, machine_id())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@
         "typer>=0.12,<1.0",
         "rtoml~=0.11.0",
         "py-machineid~=0.6.0",
+        "tzlocal~=5.2",
 
         # Frontend
         "fastapi>=0.100.1",


### PR DESCRIPTION
* Fix the timezone format via the [tzlocal](https://pypi.org/project/tzlocal/) package.
* Minor refactor in `pytest_runtest_makereport` function.