### PR TITLE
Update gh-action-sigstore-python to 3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
         if '${{ github.ref_type }}' != 'tag':
           sys.exit(f"Not on a tag")
-        
+
         gitversion = '${{ github.ref_name }}'
         version = "unknown"
 
@@ -71,7 +71,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
Update gh-action-sigstore-python to 3.0.0

Problem: https://github.com/everypinio/hardpy/actions/runs/12370737075/job/34525522403
Result: https://github.com/xorialexandrov/hardpy/actions/runs/12371271064/job/34527138466