### PR TITLE
0.9.0-rc2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<pa
 * Add the ability to add images to operator messages like a dialog box.
 * Add non-blocking mode for operator message.
 * Add `clear_operator_message` function for closing operator message.
+* Add **font_size** parameter for operator message and dialog box text.
 * Add a 1 second pause between attempts in the `attempt` marker.
 * Fix an issue where operator messages and dialog boxes sometimes did not
   open before the browser page reloaded.

--- a/docs/documentation/database.md
+++ b/docs/documentation/database.md
@@ -230,7 +230,8 @@ The **operator_msg** block contains the following fields:
   - **msg**: message for operator;
   - **title**: the title of operator message dialog box;
   - **visible**: should a message be displayed on the operator panel;
-  - **id**: operator message id.
+  - **id**: operator message id;
+  - **font_size**: operator message font size.
 
 The **modules** block contains the following fields:
 
@@ -260,8 +261,8 @@ The **modules** block contains the following fields:
             - **border**: image border in pixels;
             - **base64**: image in base64 code;
           - **visible**: should a dialog box be displayed on the operator panel;
-          - **id**: dialog box id.
-
+          - **id**: dialog box id;
+          - **font_size**: dialog box font size.
 
 Example of a **current** document:
 

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -229,6 +229,7 @@ Does not provide user interaction unlike the [run_dialog_box](#run_dialog_box) f
 - `msg` *(str)*: The message to be displayed.
 - `title` *(str | None)*: The optional title for the message.
 - `block` *(bool=True)*: If True, the function will block until the message is closed.
+- `image` *([ImageComponent](#imagecomponent) | None)*: Image information.
 - `font_size`: *(int=14)*: Text font size.
 
 **Example:**

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -228,7 +228,8 @@ Does not provide user interaction unlike the [run_dialog_box](#run_dialog_box) f
 
 - `msg` *(str)*: The message to be displayed.
 - `title` *(str | None)*: The optional title for the message.
-- `block` *(bool=True)*: if True, the function will block until the message is closed.
+- `block` *(bool=True)*: If True, the function will block until the message is closed.
+- `font_size`: *(int=14)*: Text font size.
 
 **Example:**
 
@@ -344,6 +345,7 @@ the [run_dialog_box](#run_dialog_box) function.
 If the title_bar field is missing, it is the case name.
 - `widget` *(IWidget | None)*: Widget information.
 - `image` *([ImageComponent](#imagecomponent) | None)*: Image information.
+- `font_size`: *(int=14)*: Text font size.
 
 Widget list:
 

--- a/docs/examples/dialog_box.md
+++ b/docs/examples/dialog_box.md
@@ -1,7 +1,7 @@
 # Dialog Box
 
 This is an example of testing dialog boxes using the **HardPy** library.
-The code for this example can be seen inside the hardpy package 
+The code for this example can be seen inside the hardpy package
 [Dialog Box](https://github.com/everypinio/hardpy/tree/main/examples/dialog_box).
 
 Contains some examples of valid tests for dialog boxes.
@@ -63,6 +63,7 @@ def test_text_input_with_image():
         title_bar="Example of text input",
         widget=TextInputWidget(),
         image=ImageComponent(address="assets/test.png", width=50),
+        font_size=14,
     )
     response = run_dialog_box(dbx)
     set_message(f"Entered text {response}")

--- a/docs/examples/dialog_box.md
+++ b/docs/examples/dialog_box.md
@@ -63,7 +63,7 @@ def test_text_input_with_image():
         title_bar="Example of text input",
         widget=TextInputWidget(),
         image=ImageComponent(address="assets/test.png", width=50),
-        font_size=14,
+        font_size=18,
     )
     response = run_dialog_box(dbx)
     set_message(f"Entered text {response}")

--- a/docs/examples/launch_arguments.md
+++ b/docs/examples/launch_arguments.md
@@ -1,7 +1,7 @@
 # Launch arguments
 
-**HardPy** launches pytest tests. 
-User can add own arguments and options for test execution. 
+**HardPy** launches pytest tests.
+User can add own arguments and options for test execution.
 For example, user can write own script for **HardPy** to run with special arguments, such as device serial number, and use it in tests.
 
 ### how to start
@@ -11,7 +11,7 @@ For example, user can write own script for **HardPy** to run with special argume
 3. Modify the files described below.
 4. Launch `hardpy run launch_arg`.
 
-So that you can run **HardPy** in separate scripts that use the arguments, you can use pytest's built-in `addoption` method. 
+So that you can run **HardPy** in separate scripts that use the arguments, you can use pytest's built-in `addoption` method.
 You can read more about it [here](https://docs.pytest.org/en/stable/example/simple.html#how-to-change-command-line-options-defaults).
 
 ### conftest.py
@@ -20,6 +20,7 @@ You can read more about it [here](https://docs.pytest.org/en/stable/example/simp
 def pytest_addoption(parser):
     parser.addoption("--my-opt", action="store", help="add my opt")
 
+@pytest.fixture(scope="session")
 def my_opt(request):
     return request.config.getoption("--my-opt")
 ```
@@ -27,10 +28,14 @@ def my_opt(request):
 ### test_1.py
 
 ```python
-def test_custom_option(request):
+def test_custom_option_1(request):
     custom_value = request.config.getoption("--my-opt")
     print(f"Custom option value: {custom_value}")
     assert custom_value == "hello"
+
+def test_custom_option_2(my_opt):
+    print(f"Custom option value: {my_opt}")
+    assert my_opt == "hello"
 ```
 
 ### launch test with your parameter
@@ -41,4 +46,4 @@ You can launch tests with this command:
 pytest --my-opt hello
 ```
 
-Alternatively, you can add the parameter `--my-opt hello` to the `pytest.ini` file. 
+Alternatively, you can add the parameter `--my-opt hello` to the `pytest.ini` file.

--- a/docs/examples/operator_msg.md
+++ b/docs/examples/operator_msg.md
@@ -78,7 +78,7 @@ def test_block_operator_message():
     assert True
 
 def test_not_block_operator_message():
-    set_operator_message(msg="Test not blocking operator message", title="Operator message", block=False, font_size=14)
+    set_operator_message(msg="Test not blocking operator message", title="Operator message", block=False, font_size=18)
     for i in range(3, 0, -1):
         set_message(f"Time left to complete test case {i} s", "updated_status")
         sleep(1)

--- a/docs/examples/operator_msg.md
+++ b/docs/examples/operator_msg.md
@@ -4,14 +4,14 @@ The [set_operator_message](./../documentation/pytest_hardpy.md/#set_operator_mes
 function is intended for sending messages to the operator.
 Operator messages can be used before, after, and during tests.
 
-**set_operator_message** can be used in conjunction with images. 
-To do this, the user can set the argument `image` with the 
+**set_operator_message** can be used in conjunction with images.
+To do this, the user can set the argument `image` with the
 [ImageComponent](./../documentation/pytest_hardpy.md/#imagecomponent) class.
 
 The default message to the operator blocks further execution of the code,
 but the user can set the argument `block=False` and the function will display the message
 and continue execution of the test.
-In this case, the user can clear the operator message with the 
+In this case, the user can clear the operator message with the
 [clear_operator_message](./../documentation/pytest_hardpy.md/#clear_operator_message) function.
 
 The [clear_operator_message](./../documentation/pytest_hardpy.md/#clear_operator_message)
@@ -78,7 +78,7 @@ def test_block_operator_message():
     assert True
 
 def test_not_block_operator_message():
-    set_operator_message(msg="Test not blocking operator message", title="Operator message", block=False)
+    set_operator_message(msg="Test not blocking operator message", title="Operator message", block=False, font_size=14)
     for i in range(3, 0, -1):
         set_message(f"Time left to complete test case {i} s", "updated_status")
         sleep(1)

--- a/examples/dialog_box/test_2_input_field.py
+++ b/examples/dialog_box/test_2_input_field.py
@@ -18,7 +18,7 @@ def test_text_input():
         dialog_text="Type 'ok' and press the Confirm button",
         title_bar="Example of text input",
         widget=TextInputWidget(),
-        font_size=14,
+        font_size=18,
     )
     response = run_dialog_box(dbx)
     set_message(f"Entered text {response}")
@@ -32,7 +32,7 @@ def test_text_input_with_image():
         title_bar="Example of text input",
         widget=TextInputWidget(),
         image=ImageComponent(address="assets/image.png", width=100),
-        font_size=14,
+        font_size=18,
     )
     response = run_dialog_box(dbx)
     set_message(f"Entered text {response}")

--- a/examples/dialog_box/test_2_input_field.py
+++ b/examples/dialog_box/test_2_input_field.py
@@ -18,6 +18,7 @@ def test_text_input():
         dialog_text="Type 'ok' and press the Confirm button",
         title_bar="Example of text input",
         widget=TextInputWidget(),
+        font_size=14,
     )
     response = run_dialog_box(dbx)
     set_message(f"Entered text {response}")
@@ -31,6 +32,7 @@ def test_text_input_with_image():
         title_bar="Example of text input",
         widget=TextInputWidget(),
         image=ImageComponent(address="assets/image.png", width=100),
+        font_size=14,
     )
     response = run_dialog_box(dbx)
     set_message(f"Entered text {response}")

--- a/examples/operator_msg/test_1.py
+++ b/examples/operator_msg/test_1.py
@@ -24,7 +24,7 @@ def test_not_block_operator_message():
         msg="Test not blocking operator message",
         title="Operator message",
         block=False,
-        font_size=14,
+        font_size=18,
     )
     for i in range(3, 0, -1):
         set_message(f"Time left to complete test case {i} s", "updated_status")

--- a/examples/operator_msg/test_1.py
+++ b/examples/operator_msg/test_1.py
@@ -24,6 +24,7 @@ def test_not_block_operator_message():
         msg="Test not blocking operator message",
         title="Operator message",
         block=False,
+        font_size=14,
     )
     for i in range(3, 0, -1):
         set_message(f"Time left to complete test case {i} s", "updated_status")

--- a/examples/operator_msg/test_2_image.py
+++ b/examples/operator_msg/test_2_image.py
@@ -27,7 +27,7 @@ def test_not_block_operator_message():
         title="Operator message",
         image=ImageComponent(address="assets/image.png", width=100),
         block=False,
-        font_size=14,
+        font_size=18,
     )
     for i in range(3, 0, -1):
         set_message(f"Time left to complete test case {i} s", "updated_status")

--- a/examples/operator_msg/test_2_image.py
+++ b/examples/operator_msg/test_2_image.py
@@ -27,6 +27,7 @@ def test_not_block_operator_message():
         title="Operator message",
         image=ImageComponent(address="assets/image.png", width=100),
         block=False,
+        font_size=14,
     )
     for i in range(3, 0, -1):
         set_message(f"Time left to complete test case {i} s", "updated_status")

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
@@ -27,6 +27,7 @@ interface Props {
   image_border?: number;
   is_visible?: boolean;
   id?: string;
+  font_size?: number;
 }
 
 export enum WidgetType {
@@ -335,7 +336,7 @@ export function StartConfirmationDialog(props: Props) {
         minHeight: screenHeight * minSize,
         maxWidth: screenWidth * maxSize,
         maxHeight: screenHeight * maxSize,
-        fontSize: "1rem",
+        fontSize: `${props.font_size}px`,
       }}
     >
       <div

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
@@ -391,6 +391,7 @@ export function StartConfirmationDialog(props: Props) {
                   checked={selectedRadioButton === option}
                   onChange={() => setSelectedRadioButton(option)}
                   onKeyDown={handleKeyDown}
+                  fontSize={`${props.font_size}px`}
                   autoFocus={option === (props.widget_info?.fields ?? [])[0]}
                 />
               ))}
@@ -407,6 +408,7 @@ export function StartConfirmationDialog(props: Props) {
                   checked={selectedCheckboxes.includes(option)}
                   autoFocus={option === (props.widget_info?.fields ?? [])[0]}
                   onKeyDown={handleKeyDown}
+                  fontSize={`${props.font_size}px`}
                   onChange={() => {
                     if (selectedCheckboxes.includes(option)) {
                       setSelectedCheckboxes(
@@ -427,6 +429,7 @@ export function StartConfirmationDialog(props: Props) {
                 id={step.info?.title}
                 key={step.info?.title}
                 title={step.info?.title}
+                fontSize={`${props.font_size}px`}
                 panel={
                   <div className="step-container">
                     <div className="step-content">

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
@@ -391,7 +391,7 @@ export function StartConfirmationDialog(props: Props) {
                   checked={selectedRadioButton === option}
                   onChange={() => setSelectedRadioButton(option)}
                   onKeyDown={handleKeyDown}
-                  fontSize={`${props.font_size}px`}
+                  style={{ fontSize: `${props.font_size}px` }}
                   autoFocus={option === (props.widget_info?.fields ?? [])[0]}
                 />
               ))}
@@ -408,7 +408,7 @@ export function StartConfirmationDialog(props: Props) {
                   checked={selectedCheckboxes.includes(option)}
                   autoFocus={option === (props.widget_info?.fields ?? [])[0]}
                   onKeyDown={handleKeyDown}
-                  fontSize={`${props.font_size}px`}
+                  style={{ fontSize: `${props.font_size}px` }}
                   onChange={() => {
                     if (selectedCheckboxes.includes(option)) {
                       setSelectedCheckboxes(
@@ -429,7 +429,7 @@ export function StartConfirmationDialog(props: Props) {
                 id={step.info?.title}
                 key={step.info?.title}
                 title={step.info?.title}
-                fontSize={`${props.font_size}px`}
+                style={{ fontSize: `${props.font_size}px` }}
                 panel={
                   <div className="step-container">
                     <div className="step-content">

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/DialogBox.tsx
@@ -94,7 +94,7 @@ export function StartConfirmationDialog(props: Props) {
   const baseDialogDimensions = { width: 100, height: 100 };
   const maxSize = 0.6;
   const minSize = 0.25;
-  const lineHeight = 10;
+  const lineHeight = 10 * (props.font_size ? props.font_size : 14) / 14;
 
   const handleClose = () => {
     setDialogOpen(false);

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/OperatorMsg.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/OperatorMsg.tsx
@@ -27,7 +27,7 @@ export function StartOperatorMsgDialog(props: StartOperatorMsgDialogProps) {
   const baseOperatorMessageDimensions = { width: 100, height: 100 };
   const maxSize = 0.6;
   const minSize = 0.25;
-  const lineHeight = 10;
+  const lineHeight = 10 * (props.font_size ? props.font_size : 14) / 14;
 
   const handleClose = async ()  => {
     setOperatorMessageOpen(false);

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/OperatorMsg.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/OperatorMsg.tsx
@@ -13,6 +13,7 @@ interface StartOperatorMsgDialogProps {
   image_border?: number;
   is_visible?: boolean;
   id?: string;
+  font_size?: number;
 }
 
 export function StartOperatorMsgDialog(props: StartOperatorMsgDialogProps) {
@@ -128,7 +129,7 @@ export function StartOperatorMsgDialog(props: StartOperatorMsgDialogProps) {
         minHeight: screenHeight * minSize,
         maxWidth: screenWidth * maxSize,
         maxHeight: screenHeight * maxSize,
-        fontSize: "1rem",
+        fontSize: `${props.font_size}px`,
       }}
     >
       <div

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
@@ -51,6 +51,7 @@ interface OperatorMsgProps {
   visible: boolean;
   image?: ImageInfo;
   id?: string;
+  font_size?: number;
 }
 
 export interface TestRunI {
@@ -153,6 +154,7 @@ export class SuiteList extends React.Component<Props> {
                 image_border={this.props.db_state.operator_msg?.image?.border}
                 is_visible={this.props.db_state.operator_msg?.visible}
                 id={this.props.db_state.operator_msg?.id}
+                font_size={this.props.db_state.operator_msg?.font_size}
               />
             )}
         </div>

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestSuite.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestSuite.tsx
@@ -47,6 +47,7 @@ interface DialogBoxProps {
   image?: ImageInfo;
   visible: boolean;
   id: string;
+  font_size?: number;
 }
 
 interface Case {
@@ -340,6 +341,7 @@ export class TestSuite extends React.Component<Props, State> {
               image_border={image_border}
               is_visible={test.dialog_box.visible}
               id={test.dialog_box.id}
+              font_size={test.dialog_box.font_size}
             />
           )}
         <TestStatus

--- a/hardpy/pytest_hardpy/db/const.py
+++ b/hardpy/pytest_hardpy/db/const.py
@@ -33,3 +33,4 @@ class DatabaseField(str, Enum):
     VISIBLE = "visible"
     IMAGE = "image"
     ID = "id"
+    FONT_SIZE = "font_size"

--- a/hardpy/pytest_hardpy/db/schema/v1.py
+++ b/hardpy/pytest_hardpy/db/schema/v1.py
@@ -44,7 +44,8 @@ class CaseStateStore(IBaseResult):
             "type": "textinput"
           },
           visible: true,
-          id: "af6ac3e7-7ce8-4a6b-bb9d-88c3e10b5c7a"
+          id: "af6ac3e7-7ce8-4a6b-bb9d-88c3e10b5c7a",
+          font_size: 10
         }
       }
     }
@@ -271,7 +272,8 @@ class ResultStateStore(IBaseResult):
                   "type": "textinput"
                 },
                 visible: true,
-                id: "f45bc1e7-2c18-4a4b-2b9d-8863e30bcc78"
+                id: "f45bc1e7-2c18-4a4b-2b9d-8863e30bcc78",
+                font_size: 10
               }
             },
             "test_minute_parity": {

--- a/hardpy/pytest_hardpy/db/schema/v1.py
+++ b/hardpy/pytest_hardpy/db/schema/v1.py
@@ -45,7 +45,7 @@ class CaseStateStore(IBaseResult):
           },
           visible: true,
           id: "af6ac3e7-7ce8-4a6b-bb9d-88c3e10b5c7a",
-          font_size: 10
+          font_size: 14
         }
       }
     }
@@ -273,7 +273,7 @@ class ResultStateStore(IBaseResult):
                 },
                 visible: true,
                 id: "f45bc1e7-2c18-4a4b-2b9d-8863e30bcc78",
-                font_size: 10
+                font_size: 14
               }
             },
             "test_minute_parity": {

--- a/hardpy/pytest_hardpy/pytest_call.py
+++ b/hardpy/pytest_hardpy/pytest_call.py
@@ -342,13 +342,17 @@ def set_operator_message(
     key = reporter.generate_key(DF.OPERATOR_MSG)
     _cleanup_widget(reporter, key)
 
+    if font_size < 1:
+        msg = "The 'font_size' argument cannot be less than 1"
+        raise ValueError(msg)
+
     msg_data = {
         DF.MSG: msg,
         DF.TITLE: title,
         DF.VISIBLE: True,
         DF.IMAGE: image.to_dict() if image else None,
         DF.ID: str(uuid4()),
-        DF.FONT_SIZE: font_size,
+        DF.FONT_SIZE: int(font_size),
     }
     reporter.set_doc_value(key, msg_data, statestore_only=True)
     reporter.update_db_by_doc()

--- a/hardpy/pytest_hardpy/pytest_call.py
+++ b/hardpy/pytest_hardpy/pytest_call.py
@@ -324,6 +324,7 @@ def set_operator_message(
     title: str | None = None,
     block: bool = True,
     image: ImageComponent | None = None,
+    font_size: int = 10,
 ) -> None:
     """Set operator message.
 
@@ -335,6 +336,7 @@ def set_operator_message(
         title (str | None): title
         image (ImageComponent | None): operator message info
         block (bool): if True, the function will block until the message is closed
+        font_size (int): font size
     """
     reporter = RunnerReporter()
     key = reporter.generate_key(DF.OPERATOR_MSG)
@@ -346,6 +348,7 @@ def set_operator_message(
         DF.VISIBLE: True,
         DF.IMAGE: image.to_dict() if image else None,
         DF.ID: str(uuid4()),
+        DF.FONT_SIZE: font_size,
     }
     reporter.set_doc_value(key, msg_data, statestore_only=True)
     reporter.update_db_by_doc()

--- a/hardpy/pytest_hardpy/pytest_call.py
+++ b/hardpy/pytest_hardpy/pytest_call.py
@@ -324,7 +324,7 @@ def set_operator_message(
     title: str | None = None,
     block: bool = True,
     image: ImageComponent | None = None,
-    font_size: int = 10,
+    font_size: int = 14,
 ) -> None:
     """Set operator message.
 

--- a/hardpy/pytest_hardpy/utils/dialog_box.py
+++ b/hardpy/pytest_hardpy/utils/dialog_box.py
@@ -325,7 +325,7 @@ class DialogBox:
         title_bar: str | None = None,
         widget: IWidget | None = None,
         image: ImageComponent | None = None,
-        font_size: int = 10,
+        font_size: int = 14,
     ) -> None:
         self.widget: IWidget = BaseWidget() if widget is None else widget
         self.image: ImageComponent | None = image

--- a/hardpy/pytest_hardpy/utils/dialog_box.py
+++ b/hardpy/pytest_hardpy/utils/dialog_box.py
@@ -316,6 +316,7 @@ class DialogBox:
         title_bar (str | None): title bar
         widget (IWidget | None): widget info
         image (ImageComponent | None): image
+        font_size (int): font size
     """
 
     def __init__(
@@ -324,6 +325,7 @@ class DialogBox:
         title_bar: str | None = None,
         widget: IWidget | None = None,
         image: ImageComponent | None = None,
+        font_size: int = 10,
     ) -> None:
         self.widget: IWidget = BaseWidget() if widget is None else widget
         self.image: ImageComponent | None = image
@@ -331,6 +333,7 @@ class DialogBox:
         self.title_bar: str | None = title_bar
         self.visible: bool = True
         self.id = str(uuid4())
+        self.font_size = font_size
 
     def to_dict(self) -> dict:
         """Convert DialogBox to dictionary.

--- a/hardpy/pytest_hardpy/utils/dialog_box.py
+++ b/hardpy/pytest_hardpy/utils/dialog_box.py
@@ -335,6 +335,10 @@ class DialogBox:
         self.id = str(uuid4())
         self.font_size = font_size
 
+        if font_size < 1:
+            msg = "The 'font_size' argument cannot be less than 1"
+            raise ValueError(msg)
+
     def to_dict(self) -> dict:
         """Convert DialogBox to dictionary.
 


### PR DESCRIPTION
# 0.9.0-rc2

* Add the ability to add images to operator messages like a dialog box.
* Add non-blocking mode for operator message.
* Add `clear_operator_message` function for closing operator message.
* Add `font_size` argument for `DilaogBox` and `set_operator_message`.
* Fix an issue where operator messages and dialog boxes sometimes did not open before the browser page reloaded.