### PR TITLE
Add development mode

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -4,3 +4,4 @@
 !settings.default.json
 !extensions.json
 !cspell.json
+!tasks.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "njpwerner.autodocstring",
         "charliermarsh.ruff",
         "bungcip.better-toml",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "spmeesseman.vscode-taskexplorer"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,5 +112,29 @@
                 "examples/operator_msg"
             ]
         },
+        {
+            "name": "Run Frontend",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/hardpy/hardpy_panel/frontend",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": [
+                "start-dev"
+            ],
+            "env": {
+                "DEBUG": "1",
+                "DANGEROUSLY_DISABLE_HOST_CHECK": "true"
+            },
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Debug Frontend",
+            "type": "chrome",
+            "request": "launch",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}/hardpy/hardpy_panel/frontend",
+            "sourceMaps": true,
+            "timeout": 30000
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,9 +85,6 @@
             "request": "launch",
             "module": "hardpy.cli.cli",
             "console": "integratedTerminal",
-            "env": {
-                "DEBUG_FRONTEND": "1"
-            },
             "args": [
                 "run",
                 "examples/dialog_box"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,9 @@
             "request": "launch",
             "module": "hardpy.cli.cli",
             "console": "integratedTerminal",
+            "env": {
+                "DEBUG_FRONTEND": "1"
+            },
             "args": [
                 "run",
                 "examples/dialog_box"
@@ -122,7 +125,6 @@
                 "start-dev"
             ],
             "env": {
-                "DEBUG": "1",
                 "DANGEROUSLY_DISABLE_HOST_CHECK": "true"
             },
             "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -125,7 +125,8 @@
                 "DEBUG": "1",
                 "DANGEROUSLY_DISABLE_HOST_CHECK": "true"
             },
-            "console": "integratedTerminal"
+            "console": "integratedTerminal",
+            "preLaunchTask": "yarn install"
         },
         {
             "name": "Debug Frontend",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "outDir": "\"${workspaceRoot}\\bin\"",
+    "tasks": [
+        {
+            "label": "yarn install",
+            "type": "shell",
+            "command": "yarn",
+            "args": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "${workspaceFolder}/hardpy/hardpy_panel/frontend"
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -64,7 +64,8 @@ pip install -r requirements-doc.txt
 ## Frontend
 
 ### Overview
-The frontend of the project can be developed, debugged, and built using Visual Studio Code (VSCode) or command-line tools. Below are the steps to run, debug, and build the frontend application.
+The frontend of the project can be developed, debugged, and built using Visual Studio Code (VSCode) or command-line tools. 
+Below are the steps to run, debug, and build the frontend application.
 
 **node.js** and **yarn** are required to build the frontend.
 
@@ -83,9 +84,7 @@ This will:
 #### Manually:
 Navigate to the frontend directory and run the following commands:
 ```bash
-cd hardpy/hardpy_panel/frontend
-yarn
-DANGEROUSLY_DISABLE_HOST_CHECK=true yarn start-dev
+yarn && DANGEROUSLY_DISABLE_HOST_CHECK=true yarn start-dev
 ```
 
 ### 2. Debugging the Frontend
@@ -134,68 +133,44 @@ pip install -r requirements.txt
 python -m build
 ```
 
-### VSCode Configuration Files
-Below are the configurations for `tasks.json` and `launch.json` to streamline the development process in VSCode.
+### 4. Setting the `DEBUG_FRONTEND` Variable
+To enable debugging for the frontend application, you must set the `DEBUG_FRONTEND` environment variable. 
+Without this variable, the frontend will not run in debug mode, and the **Run Frontend** and **Debug Frontend** configurations will not work as expected.
 
-#### `tasks.json`:
-This file defines tasks for installing dependencies and building the frontend.
+#### Option 1: Setting `DEBUG_FRONTEND` in VSCode Configuration
+You can specify the `DEBUG_FRONTEND` variable directly in the VSCode launch configuration. 
+Here’s an example of how to include it in a test configuration:
+
 ```json
 {
-    "version": "2.0.0",
-    "outDir": "\"${workspaceRoot}\\bin\"",
-    "tasks": [
-        {
-            "label": "yarn install",
-            "type": "shell",
-            "command": "yarn",
-            "args": [],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "options": {
-                "cwd": "${workspaceFolder}/hardpy/hardpy_panel/frontend"
-            },
-            "problemMatcher": []
-        }
+    "name": "Python: Example Dialog box",
+    "type": "debugpy",
+    "request": "launch",
+    "module": "hardpy.cli.cli",
+    "console": "integratedTerminal",
+    "env": {
+        "DEBUG_FRONTEND": "1"
+    },
+    "args": [
+        "run",
+        "examples/dialog_box"
     ]
 }
 ```
 
-#### `launch.json`:
-This file defines configurations for running and debugging the frontend.
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Run Frontend",
-            "type": "node",
-            "request": "launch",
-            "cwd": "${workspaceFolder}/hardpy/hardpy_panel/frontend",
-            "runtimeExecutable": "yarn",
-            "runtimeArgs": [
-                "start-dev"
-            ],
-            "env": {
-                "DEBUG": "1",
-                "DANGEROUSLY_DISABLE_HOST_CHECK": "true"
-            },
-            "console": "integratedTerminal",
-            "preLaunchTask": "yarn install"
-        },
-        {
-            "name": "Debug Frontend",
-            "type": "chrome",
-            "request": "launch",
-            "url": "http://localhost:3000",
-            "webRoot": "${workspaceFolder}/hardpy/hardpy_panel/frontend",
-            "sourceMaps": true,
-            "timeout": 30000
-        }
-    ]
-}
+This configuration ensures that the frontend runs in debug mode when the test is executed.
+
+#### Option 2: Setting `DEBUG_FRONTEND` in `.env` File
+Alternatively, you can define the `DEBUG_FRONTEND` variable in a `.env` file located in the root of your project. 
+
+1. Create a `.env` file in the root directory of your project (if it doesn’t already exist).
+2. Add the following line to the `.env` file:
+
+```env
+DEBUG_FRONTEND=1
 ```
+
+3. Ensure your VSCode or runtime environment loads the `.env` file. Many tools and frameworks (e.g., `python-dotenv`) automatically load variables from `.env`.
 
 ## Launch
 

--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -87,6 +87,12 @@ Navigate to the frontend directory and run the following commands:
 yarn && DANGEROUSLY_DISABLE_HOST_CHECK=true yarn start-dev
 ```
 
+You can specify your own port by adding it as an environment variable:
+```bash
+PORT=4000
+```
+By default, the frontend opens on port 3000 at the address [http://localhost:3000/](http://localhost:3000/).
+
 ### 2. Debugging the Frontend
 To debug the frontend application in the Chrome browser, use the **Debug Frontend** configuration in VSCode.
 

--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -95,7 +95,7 @@ To edit the frontend, you can use the debugging mode in Visual Studio Code (VSCo
 
 1. **Run Frontend**: This configuration is responsible for starting the frontend application.
 2. **Debug Frontend**: This configuration is used to debug the frontend application in the Chrome browser. 
-3. Any example, such as a Dialog Box (the backend should be running beforehand).
+3. Any example, such as a Dialog Box (the DB should be running beforehand).
 
 ## Launch
 

--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -89,6 +89,14 @@ pip install -r requirements.txt
 python -m build
 ```
 
+## Frontend development in VSCode
+
+To edit the frontend, you can use the debugging mode in Visual Studio Code (VSCode). To do this, you need to run the following configurations in the VSCode debugger:
+
+1. **Run Frontend**: This configuration is responsible for starting the frontend application.
+2. **Debug Frontend**: This configuration is used to debug the frontend application in the Chrome browser. 
+3. Any example, such as a Dialog Box (the backend should be running beforehand).
+
 ## Launch
 
 1. Install dependencies or create environment.

--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -61,9 +61,54 @@ pip install -r requirements.txt
 pip install -r requirements-doc.txt
 ```
 
-## Frontend building
+## Frontend
+
+### Overview
+The frontend of the project can be developed, debugged, and built using Visual Studio Code (VSCode) or command-line tools. Below are the steps to run, debug, and build the frontend application.
 
 **node.js** and **yarn** are required to build the frontend.
+
+### 1. Running the Frontend for Hardpy Debugging
+To run the frontend application for debugging purposes, you can use the **Run Frontend** configuration in VSCode or execute commands manually.
+
+#### Using VSCode:
+1. Open the "Run and Debug" in VSCode.
+2. Select the **Run Frontend** configuration.
+3. Click the "Run" button (or press `F5`).
+
+This will:
+- Launch `yarn`.
+- Start the frontend application in development mode with debugging enabled.
+
+#### Manually:
+Navigate to the frontend directory and run the following commands:
+```bash
+cd hardpy/hardpy_panel/frontend
+yarn
+DANGEROUSLY_DISABLE_HOST_CHECK=true yarn start-dev
+```
+
+### 2. Debugging the Frontend
+To debug the frontend application in the Chrome browser, use the **Debug Frontend** configuration in VSCode.
+
+#### Using VSCode:
+1. Ensure the frontend is running (use the **Run Frontend** configuration or manually start it).
+2. Open the "Run and Debug" in VSCode.
+3. Select the **Debug Frontend** configuration.
+4. Click the "Run" button (or press `F5`).
+
+This will:
+- Launch Chrome and attach the debugger to the running frontend application at `http://localhost:3000`.
+- Enable source maps for easier debugging.
+
+#### Manually:
+1. Start the frontend application (as described in the **Run Frontend** section).
+2. Open Chrome and navigate to `http://localhost:3000`.
+3. Use Chrome DevTools (`F12`) to debug the application.
+
+
+### 3. Building the Frontend for Hardpy Package
+To build the frontend and include it in the Hardpy package, you can use the provided scripts or run the commands manually.
 
 Use the `compile_front.sh` script from `scripts` folder
 or run the scripts manually:
@@ -89,13 +134,68 @@ pip install -r requirements.txt
 python -m build
 ```
 
-## Frontend development in VSCode
+### VSCode Configuration Files
+Below are the configurations for `tasks.json` and `launch.json` to streamline the development process in VSCode.
 
-To edit the frontend, you can use the debugging mode in Visual Studio Code (VSCode). To do this, you need to run the following configurations in the VSCode debugger:
+#### `tasks.json`:
+This file defines tasks for installing dependencies and building the frontend.
+```json
+{
+    "version": "2.0.0",
+    "outDir": "\"${workspaceRoot}\\bin\"",
+    "tasks": [
+        {
+            "label": "yarn install",
+            "type": "shell",
+            "command": "yarn",
+            "args": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "${workspaceFolder}/hardpy/hardpy_panel/frontend"
+            },
+            "problemMatcher": []
+        }
+    ]
+}
+```
 
-1. **Run Frontend**: This configuration is responsible for starting the frontend application.
-2. **Debug Frontend**: This configuration is used to debug the frontend application in the Chrome browser. 
-3. Any example, such as a Dialog Box (the DB should be running beforehand).
+#### `launch.json`:
+This file defines configurations for running and debugging the frontend.
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Frontend",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/hardpy/hardpy_panel/frontend",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": [
+                "start-dev"
+            ],
+            "env": {
+                "DEBUG": "1",
+                "DANGEROUSLY_DISABLE_HOST_CHECK": "true"
+            },
+            "console": "integratedTerminal",
+            "preLaunchTask": "yarn install"
+        },
+        {
+            "name": "Debug Frontend",
+            "type": "chrome",
+            "request": "launch",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}/hardpy/hardpy_panel/frontend",
+            "sourceMaps": true,
+            "timeout": 30000
+        }
+    ]
+}
+```
 
 ## Launch
 

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Everypin
 # GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import os
 import re
 from enum import Enum
 from pathlib import Path
@@ -119,11 +120,12 @@ def confirm_operator_msg(is_msg_visible: str) -> dict:
     return {"status": Status.ERROR}
 
 
-app.mount(
-    "/",
-    StaticFiles(
-        directory=Path(__file__).parent / "frontend/dist",
-        html=True,
-    ),
-    name="static",
-)
+if "DEBUG" not in os.environ:
+    app.mount(
+        "/",
+        StaticFiles(
+            directory=Path(__file__).parent / "frontend/dist",
+            html=True,
+        ),
+        name="static",
+    )

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -120,7 +120,7 @@ def confirm_operator_msg(is_msg_visible: str) -> dict:
     return {"status": Status.ERROR}
 
 
-if "DEBUG" not in os.environ:
+if "DEBUG_FRONTEND" not in os.environ:
     app.mount(
         "/",
         StaticFiles(

--- a/hardpy/hardpy_panel/frontend/.eslintrc
+++ b/hardpy/hardpy_panel/frontend/.eslintrc
@@ -18,7 +18,7 @@
     ],
     "rules": {
         "@typescript-eslint/no-unused-vars": [
-            2,
+            "warn",
             {
                 "args": "after-used",
                 "argsIgnorePattern": "^_"

--- a/hardpy/hardpy_panel/frontend/package.json
+++ b/hardpy/hardpy_panel/frontend/package.json
@@ -89,5 +89,6 @@
     "@typescript-eslint/parser": "^6.9.0",
     "eslint": "^8.52.0",
     "eslint-plugin-react-hooks": "^4.6.0"
-  }
+  },
+  "proxy": "http://localhost:8000"
 }

--- a/scripts/compile_front.sh
+++ b/scripts/compile_front.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEBUG=0
+DEBUG_FRONTEND=0
 cd ..
 pip install -r requirements.txt
 python -m build

--- a/scripts/compile_front.sh
+++ b/scripts/compile_front.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+DEBUG=0
 cd ..
 pip install -r requirements.txt
 python -m build

--- a/scripts/recompile_front.sh
+++ b/scripts/recompile_front.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PRJ=hardpy
-DEBUG=0
+DEBUG_FRONTEND=0
 cd ..
 
 # Uninstall package

--- a/scripts/recompile_front.sh
+++ b/scripts/recompile_front.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PRJ=hardpy
-
+DEBUG=0
 cd ..
 
 # Uninstall package


### PR DESCRIPTION
Add development mode

# Frontend development in VSCode

To edit the frontend, you can use the debugging mode in Visual Studio Code (VSCode). To do this, you need to run the following configurations in the VSCode debugger:

1. **Run Frontend**: This configuration is responsible for starting the frontend application.
2. **Debug Frontend**: This configuration is used to debug the frontend application in the Chrome browser. 
3. Any example, such as a Dialog Box (the DB should be running beforehand).