### PR TITLE
Update hatchling to 1.27.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@
         pytest_hardpy = "hardpy.pytest_hardpy.plugin"
 
 [build-system]
-    requires = ["hatchling==1.21.1"]
+    requires = ["hatchling==1.27.0"]
     build-backend = "hatchling.build"
 
 [tool.hatch.build]


### PR DESCRIPTION
# About

Update hatching build backend to 1.27.0 for updating package metadata from 2.1 to 2.4.

* Problem action: https://github.com/everypinio/hardpy/actions/runs/13631849618/job/38101326961

`hatching==1.21.1` metadata info:
```
Metadata-Version: 2.1
Name: hardpy
Version: 0.10.0
```

`hatching==1.27.0` metadata info:
```
Metadata-Version: 2.4
Name: hardpy
Version: 0.10.0
```