### PR TITLE
0.11.0 package update

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,21 +2,31 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+## HardPy 0.11.0
+
 * Remove the internal **HardPy** socket on port 6525. Pytest plugin arguments `--hardpy-sh` and `--hardpy-sp`
   are left for backward compatibility with version below 0.10.1.
-* Add the ability to add html-pages to dialog boxes and operator messages.
+  [[PR-114](https://github.com/everypinio/hardpy/pull/114)]
+* Add the ability to add HTML pages using `HTMLComponent` to dialog boxes and operator messages.
+  [[PR-104](https://github.com/everypinio/hardpy/pull/104)]
 
 ## HardPy 0.10.1
 
 * Fix **StandCloud** authorization process in Windows.
+  [[PR-110](https://github.com/everypinio/hardpy/pull/110)]
 
 ## HardPy 0.10.0
 
 * Add the `[stand_cloud]` section to the **hardpy.toml** configuration file.
+  [[PR-85](https://github.com/everypinio/hardpy/pull/85)]
 * Add the `StandCloudLoader` class to append the test result to the **StandCloud**.
+  [[PR-85](https://github.com/everypinio/hardpy/pull/85)]
 * Add support for **StandCloud** login and logout with `sc-login` and `sc-logout` commands.
+  [[PR-85](https://github.com/everypinio/hardpy/pull/85)]
 * Add **alert** field in **statestore** database.
+  [[PR-85](https://github.com/everypinio/hardpy/pull/85)]
 * Add alert to control panel by calling `set_alert` method in `HardpyPlugin`.
+  [[PR-85](https://github.com/everypinio/hardpy/pull/85)]
 
 ## HardPy 0.9.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
     name = "hardpy"
-    version = "0.10.1"
+    version = "0.11.0"
     description = "HardPy library for device testing"
     license = "GPL-3.0-or-later"
     authors = [{ name = "Everypin", email = "info@everypin.io" }]


### PR DESCRIPTION
## About 0.11.0

1. Remove the internal **HardPy** socket on port 6525. Pytest plugin arguments `--hardpy-sh` and `--hardpy-sp`
  are left for backward compatibility with version below 0.10.1. #114
2. Add the ability to add HTML pages using `HTMLComponent` to dialog boxes and operator messages. #104 

## Details

### Socket

* Removed the internal **HardPy** socket on port 6525. 
* Pytest plugin arguments `--hardpy-sh` and `--hardpy-sp` are left for backward compatibility with version below 0.10.1.
* When the major version is released, it is necessary to remove these args from **plugin.py**. A **TODO** note was left about it.
* Removed `[socket]` section from the **hardpy.toml** file.
* Added `update_doc_by_db` function for document synchronization in some reporter instances.
* Documentation and tests updated. 

### HTMLComponent

* Added the ability to add HTML pages to dialog boxes and operator messages using the `HTMLComponent` class.
* Added the ability to insert a link to an html page, or insert raw html code.
* Added an example of generating plot in an HTML page.

![image](https://github.com/user-attachments/assets/ab35522b-ed91-4274-9b51-fa2c56464790)


