### PR TITLE
StandCloud endpoints renaming

### DIFF
--- a/hardpy/common/stand_cloud/connector.py
+++ b/hardpy/common/stand_cloud/connector.py
@@ -59,7 +59,7 @@ class StandCloudConnector:
         auth_addr = addr + "/auth"
 
         self._url: StandCloudURL = StandCloudURL(
-            api=https_prefix + addr + self._get_service_name(addr) + "/api/v1",
+            api=https_prefix + addr + "/hardpy/api/v1",
             token=https_prefix + auth_addr + "/api/oidc/token",
             par=https_prefix + auth_addr + "/api/oidc/pushed-authorization-request",
             auth=https_prefix + auth_addr + "/api/oidc/authorization",
@@ -216,12 +216,3 @@ class StandCloudConnector:
             expires_at=expires_at,
             expires_in=expires_in,
         )
-
-    def _get_service_name(self, addr: str) -> str:
-        addr_parts = addr.split(".")
-        number_of_parts = 3
-        service_position_in_address = 1
-        if isinstance(addr_parts, list) and len(addr_parts) >= number_of_parts:
-            return "/" + addr_parts[service_position_in_address]
-        msg = f"Invalid StandCloud address: {addr}"
-        raise StandCloudError(msg)

--- a/hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py
+++ b/hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py
@@ -45,7 +45,7 @@ class StandCloudLoader:
         Raises:
             StandCloudError: if report not uploaded to StandCloud
         """
-        api = self._sc_connector.get_api("api/test_run")
+        api = self._sc_connector.get_api("test_run")
 
         try:
             resp = api.post(verify=self._verify_ssl, json=report.model_dump())


### PR DESCRIPTION
## About

* Rename `test_run` **StandCloud** endpoints: `api/test_run` -> `test_run`.
* Rename the **StandCloud** API address to `hardpy`. The API is now service independent.
