### PR TITLE
Tests name and new CLI commands

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -70,7 +70,8 @@ indent-width = 4
         ]
         "hardpy/cli/cli.py" = [
             "T201",   # using print
-            "UP007"   # Non PEP 604 annotation
+            "UP007",  # Non PEP 604 annotation
+            "BLE001"  # bare except
         ]
         "hardpy/cli/template.py" = ["D102"]
         "hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py" = ["B904"] # raise ... from err

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,39 @@
             ]
         },
         {
+            "name": "HardPy: Start template",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "hardpy.cli.cli",
+            "console": "integratedTerminal",
+            "args": [
+                "start",
+                "examples/template"
+            ]
+        },
+        {
+            "name": "HardPy: Stop template",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "hardpy.cli.cli",
+            "console": "integratedTerminal",
+            "args": [
+                "stop",
+                "examples/template"
+            ]
+        },
+        {
+            "name": "HardPy: Status template",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "hardpy.cli.cli",
+            "console": "integratedTerminal",
+            "args": [
+                "status",
+                "examples/template"
+            ]
+        },
+        {
             "name": "StandCloud login",
             "type": "debugpy",
             "request": "launch",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Add the `tests_name` field to **hardpy.toml**.
+  The `tests_name` allows to name the test suite in the operator panel. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
+* Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
+* Change the StandCloud API address to `/hardpy/api`. [[PR-125](https://github.com/everypinio/hardpy/pull/125)]
+
 ## HardPy 0.11.0
 
 * Remove the internal **HardPy** socket on port 6525. Pytest plugin arguments `--hardpy-sh` and `--hardpy-sp`

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -86,6 +86,60 @@ To obtain this information, use:
 hardpy run --help
 ```
 
+## hardpy start
+
+The `hardpy start` command is used to launch **HardPy** tests while the **HardPy** opener panel is running.
+By default, it starts tests in the current directory.
+
+```bash
+ Usage: hardpy start [OPTIONS] [TESTS_DIR]
+
+ Start HardPy tests.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────╮
+│   tests_dir      [TESTS_DIR]  [default: None]                                                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## hardpy stop
+
+The `hardpy stop` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.
+By default, it stops tests in the current directory.
+
+```bash
+ Usage: hardpy stop [OPTIONS] [TESTS_DIR]
+
+ Stop HardPy tests.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────╮
+│   tests_dir      [TESTS_DIR]  [default: None]                                                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## hardpy status
+
+The `hardpy status` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.
+By default, it stops tests in the current directory.
+
+```bash
+ Usage: hardpy status [OPTIONS] [TESTS_DIR]
+
+ Get HardPy test launch status.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────╮
+│   tests_dir      [TESTS_DIR]  [default: None]                                                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
 ## sc-login
 
 The `hardpy sc-login` command is used to login in **StandCloud**.

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -37,6 +37,7 @@ More info in [hardpy config](./hardpy_config.md).
 │   tests_dir      [TESTS_DIR]  [default: None]                                                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --tests-name                                   TEXT     Specify a tests suite name.                        │
 │ --create-database      --no-create-database             Create CouchDB database.                           │
 │                                                         [default: create-database]                         │
 │ --database-user                                TEXT     Specify a database user. [default: dev]            │

--- a/docs/documentation/hardpy_config.md
+++ b/docs/documentation/hardpy_config.md
@@ -23,6 +23,28 @@ host = "localhost"
 port = 8000
 ```
 
+## Maximum configuration file
+
+```toml
+title = "HardPy TOML config"
+tests_dir = "tests"
+tests_name "My tests"
+
+[database]
+user = "dev"
+password = "dev"
+host = "localhost"
+port = 5984
+
+[frontend]
+host = "localhost"
+port = 8000
+
+[stand_cloud]
+address = "demo.standcloud.io"
+connection_only = true
+```
+
 ## Configuration fields description
 
 ### common
@@ -38,6 +60,11 @@ The value is always `HardPy TOML config`.
 
 Tests directory. The default is `tests`.
 The user can change this value with the `hardpy init` argument.
+
+#### tests_name
+
+Tests name. The default is [tests_dir](#tests_dir).
+The user can change this value with the `hardpy init --tests-name` argument.
 
 ### database
 

--- a/docs/documentation/hardpy_config.md
+++ b/docs/documentation/hardpy_config.md
@@ -28,7 +28,7 @@ port = 8000
 ```toml
 title = "HardPy TOML config"
 tests_dir = "tests"
-tests_name "My tests"
+tests_name = "My tests"
 
 [database]
 user = "dev"

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -702,6 +702,15 @@ The default is `http://dev:dev@localhost:5984/`.
 --hardpy-db-url
 ```
 
+#### hardpy-tests-name
+
+The **HardPy** tests name.
+The default value is **Tests**.
+
+```bash
+--hardpy-tests-name
+```
+
 #### hardpy-clear-database
 
 Option to clean **statestore** and **runstore** databases before running pytest.

--- a/docs/examples/hardpy_launch.md
+++ b/docs/examples/hardpy_launch.md
@@ -1,6 +1,6 @@
 # HardPy launch
 
-**HardPy** can be started from either the operator panel or the terminal. 
+**HardPy** can be started from either the operator panel or the terminal.
 Below we will look at all the launch options.
 
 ### how to start
@@ -15,32 +15,43 @@ Initialize the **HardPy** project:
 #### 1. Operator panel
 
 1. Launch operator panel:
-   ```
+   ```bash
    hardpy run test_project
    ```
 2. Open the operator panel in your browser at: [http://localhost:8000/](http://localhost:8000/).
 3. Click the **Start** button.
 
-#### 2. Pytest in console
+#### 2. Start command
+
+1. Launch operator panel:
+   ```bash
+   hardpy run test_project
+   ```
+2. Run the tests by executing the following command in the terminal:
+    ```bash
+    hardpy start test_project
+    ```
+
+#### 3. Pytest in console
 
 Run the tests by executing the following command in the terminal:
 
-```
+```bash
 pytest test_project
 ```
 
-##### 2.1. Pytest in console with launching operator panel
+##### 3.1. Pytest in console with launching operator panel
 
 If the operator panel is running, the tests will start after the command in the terminal in the same way as by clicking on the `Start` button.
 
-##### 2.2. Pytest in console without launching operator panel
+##### 3.2. Pytest in console without launching operator panel
 
 If the operator panel has not been started, the tests will also run, but without visualization.
 
 ???+ warning
     This method is only appropriate if you are not using any operator panel features such as operator messages and dialog boxes.
 
-#### 3. IDE
+#### 4. IDE
 
 An example of starting in vscode is as follows.
 If you use other IDEs, explore the possibility of running tests in your environment.
@@ -48,11 +59,11 @@ If you use other IDEs, explore the possibility of running tests in your environm
 1. Open the [Testing](https://code.visualstudio.com/docs/editor/testing) extension in VS Code.
 2. Run the tests through the extension interface.
 
-##### 3.1. Pytest in Testing with launching operator panel
+##### 4.1. Pytest in Testing with launching operator panel
 
 If the operator panel is running, the tests will start after launching in Testing in the same way as by clicking on the `Start` button.
 
-##### 3.2. Pytest in Testing without launching operator panel
+##### 4.2. Pytest in Testing without launching operator panel
 
 If the operator panel has not been started, the tests will also run, but without visualization.
 

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -21,13 +21,18 @@ Alternatively, the user can start the operator panel with the “Start” button
 python -m pytest
 ```
 
-The user can also run tests without the operator panel, just through pytest.
-This method may be appropriate if the user does not need the operator panel.
+The user can also run tests without the operator panel, just using the `hardpy start` command or
+using `pytest`.
 
 ## Stopping the tests
 
-The user can stop the tests during execution from the operator panel by clicking on the **Stop** button.
+The user can stop the tests during execution from the operator panel by clicking on the **Stop** button
+or using the `hardpy stop` command.
 It is possible to stop tests from the console by sending an interrupt, e.g. “Ctrl-C” in Linux.
+
+## Checking the status of tests
+
+The user can check the status of tests using the `hardpy status` command.
 
 ## Storing test result in database
 

--- a/hardpy/cli/cli.py
+++ b/hardpy/cli/cli.py
@@ -168,7 +168,7 @@ def start(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
         tests_dir (Optional[str]): Test directory. Current directory by default
     """
     config = _get_config(tests_dir)
-    _healthcheck(config)
+    _check_config(config)
 
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/start"
     _request_hardpy(url)
@@ -182,7 +182,7 @@ def stop(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
         tests_dir (Optional[str]): Test directory. Current directory by default
     """
     config = _get_config(tests_dir)
-    _healthcheck(config)
+    _check_config(config)
 
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/stop"
     _request_hardpy(url)
@@ -196,7 +196,7 @@ def status(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None
         tests_dir (Optional[str]): Test directory. Current directory by default
     """
     config = _get_config(tests_dir)
-    _healthcheck(config)
+    _check_config(config)
 
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/status"
     _request_hardpy(url)
@@ -256,8 +256,8 @@ def _get_config(tests_dir: str | None = None) -> HardpyConfig:
     return config
 
 
-def _healthcheck(config: HardpyConfig) -> None:
-    url = f"http://{config.frontend.host}:{config.frontend.port}/api/healthcheck"
+def _check_config(config: HardpyConfig) -> None:
+    url = f"http://{config.frontend.host}:{config.frontend.port}/api/hardpy_config"
     try:
         response = requests.get(url, timeout=2)
     except Exception:

--- a/hardpy/cli/cli.py
+++ b/hardpy/cli/cli.py
@@ -6,11 +6,12 @@ import sys
 from pathlib import Path
 from typing import Annotated, Optional
 
+import requests
 import typer
 from uvicorn import run as uvicorn_run
 
 from hardpy.cli.template import TemplateGenerator
-from hardpy.common.config import ConfigManager
+from hardpy.common.config import ConfigManager, HardpyConfig
 from hardpy.common.stand_cloud import (
     StandCloudConnector,
     StandCloudError,
@@ -31,6 +32,10 @@ default_config = ConfigManager().get_config()
 @cli.command()
 def init(  # noqa: PLR0913
     tests_dir: Annotated[Optional[str], typer.Argument()] = None,
+    tests_name: str = typer.Option(
+        default="",
+        help="Specify a tests suite name.",
+    ),
     create_database: bool = typer.Option(
         default=True,
         help="Create CouchDB database.",
@@ -72,6 +77,7 @@ def init(  # noqa: PLR0913
 
     Args:
         tests_dir (str | None): Tests directory. Current directory + `tests` by default
+        tests_name (str): Tests suite name, "Tests" by default
         create_database (bool): Flag to create database
         database_user (str): Database user name
         database_password (str): Database password
@@ -83,8 +89,10 @@ def init(  # noqa: PLR0913
         sc_connection_only (bool): Flag to check StandCloud service availability
     """
     _tests_dir = tests_dir if tests_dir else default_config.tests_dir
+    _tests_name = tests_name if tests_name else default_config.tests_name
     ConfigManager().init_config(
         tests_dir=str(_tests_dir),
+        tests_name=_tests_name,
         database_user=database_user,
         database_password=database_password,
         database_host=database_host,
@@ -153,6 +161,48 @@ def run(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
 
 
 @cli.command()
+def start(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
+    """Start HardPy tests.
+
+    Args:
+        tests_dir (Optional[str]): Test directory. Current directory by default
+    """
+    config = _get_config(tests_dir)
+    _healthcheck(config)
+
+    url = f"http://{config.frontend.host}:{config.frontend.port}/api/start"
+    _request_hardpy(url)
+
+
+@cli.command()
+def stop(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
+    """Stop HardPy tests.
+
+    Args:
+        tests_dir (Optional[str]): Test directory. Current directory by default
+    """
+    config = _get_config(tests_dir)
+    _healthcheck(config)
+
+    url = f"http://{config.frontend.host}:{config.frontend.port}/api/stop"
+    _request_hardpy(url)
+
+
+@cli.command()
+def status(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
+    """Get HardPy test launch status.
+
+    Args:
+        tests_dir (Optional[str]): Test directory. Current directory by default
+    """
+    config = _get_config(tests_dir)
+    _healthcheck(config)
+
+    url = f"http://{config.frontend.host}:{config.frontend.port}/api/status"
+    _request_hardpy(url)
+
+
+@cli.command()
 def sc_login(
     address: Annotated[str, typer.Argument()],
     check: bool = typer.Option(
@@ -193,6 +243,45 @@ def sc_logout() -> None:
         print("HardPy logout success")
     else:
         print("HardPy logout failed")
+
+
+def _get_config(tests_dir: str | None = None) -> HardpyConfig:
+    dir_path = Path.cwd() / tests_dir if tests_dir else Path.cwd()
+    config = ConfigManager().read_config(dir_path)
+
+    if not config:
+        print(f"Config at path {dir_path} not found.")
+        sys.exit()
+
+    return config
+
+
+def _healthcheck(config: HardpyConfig) -> None:
+    url = f"http://{config.frontend.host}:{config.frontend.port}/api/healthcheck"
+    try:
+        response = requests.get(url, timeout=2)
+    except Exception:
+        print(f"HardPy in directory {config.tests_dir} does not run.")
+        sys.exit()
+
+    running_config: dict = response.json()
+    if config.model_dump() != running_config:
+        print(f"HardPy in directory {config.tests_dir} does not run.")
+        sys.exit()
+
+
+def _request_hardpy(url: str) -> None:
+    try:
+        response = requests.get(url, timeout=2)
+    except Exception:
+        print("HardPy operator panel is not running.")
+        sys.exit()
+    try:
+        status: dict = response.json().get("status", "ERROR")
+    except ValueError:
+        print(f"Hardpy internal error: {response}")
+        sys.exit()
+    print(f"HardPy status: {status}")
 
 
 if __name__ == "__main__":

--- a/hardpy/cli/cli.py
+++ b/hardpy/cli/cli.py
@@ -258,15 +258,16 @@ def _get_config(tests_dir: str | None = None) -> HardpyConfig:
 
 def _check_config(config: HardpyConfig) -> None:
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/hardpy_config"
+    error_msg = f"HardPy in directory {config.tests_dir} does not run."
     try:
         response = requests.get(url, timeout=2)
     except Exception:
-        print(f"HardPy in directory {config.tests_dir} does not run.")
+        print(error_msg)
         sys.exit()
 
     running_config: dict = response.json()
     if config.model_dump() != running_config:
-        print(f"HardPy in directory {config.tests_dir} does not run.")
+        print(error_msg)
         sys.exit()
 
 
@@ -279,9 +280,9 @@ def _request_hardpy(url: str) -> None:
     try:
         status: dict = response.json().get("status", "ERROR")
     except ValueError:
-        print(f"Hardpy internal error: {response}")
+        print(f"Hardpy internal error: {response}.")
         sys.exit()
-    print(f"HardPy status: {status}")
+    print(f"HardPy status: {status}.")
 
 
 if __name__ == "__main__":

--- a/hardpy/common/config.py
+++ b/hardpy/common/config.py
@@ -57,6 +57,7 @@ class HardpyConfig(BaseModel, extra="allow"):
 
     title: str = "HardPy TOML config"
     tests_dir: str = "tests"
+    tests_name: str = ""
     database: DatabaseConfig = DatabaseConfig()
     frontend: FrontendConfig = FrontendConfig()
     stand_cloud: StandCloudConfig = StandCloudConfig()
@@ -72,6 +73,7 @@ class ConfigManager:
     def init_config(  # noqa: PLR0913
         cls,
         tests_dir: str,
+        tests_name: str,
         database_user: str,
         database_password: str,
         database_host: str,
@@ -85,6 +87,7 @@ class ConfigManager:
 
         Args:
             tests_dir (str): Tests directory.
+            tests_name (str): Tests suite name.
             database_user (str): Database user name.
             database_password (str): Database password.
             database_host (str): Database host.
@@ -95,6 +98,7 @@ class ConfigManager:
             sc_connection_only (bool): StandCloud check availability.
         """
         cls.obj.tests_dir = str(tests_dir)
+        cls.obj.tests_name = tests_name
         cls.obj.database.user = database_user
         cls.obj.database.password = database_password
         cls.obj.database.host = database_host
@@ -113,6 +117,8 @@ class ConfigManager:
         """
         if not cls.obj.stand_cloud.address:
             del cls.obj.stand_cloud
+        if not cls.obj.tests_name:
+            del cls.obj.tests_name
         config_str = tomli_w.dumps(cls.obj.model_dump())
         with Path.open(parent_dir / "hardpy.toml", "w") as file:
             file.write(config_str)

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -23,8 +23,6 @@ class Status(str, Enum):
     Statuses, that can be returned by HardPy API.
     """
 
-    OK = "ok"
-    NOT_RUNNING = "not running"
     STOPPED = "stopped"
     STARTED = "started"
     COLLECTED = "collected"

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -18,17 +18,29 @@ app.state.pytest_wrp = PyTestWrapper()
 
 
 class Status(str, Enum):
-    """Pytest run status.
+    """HardPy status.
 
-    Statuses, that can be returned by HardPy to frontend.
+    Statuses, that can be returned by HardPy API.
     """
 
+    OK = "ok"
+    NOT_RUNNING = "not running"
     STOPPED = "stopped"
     STARTED = "started"
     COLLECTED = "collected"
     BUSY = "busy"
     READY = "ready"
     ERROR = "error"
+
+
+@app.get("/api/hardpy_config")
+def hardpy_config() -> dict:
+    """Get config of HardPy.
+
+    Returns:
+        dict: HardPy config
+    """
+    return app.state.pytest_wrp.get_config()
 
 
 @app.get("/api/start")
@@ -66,6 +78,18 @@ def collect_pytest() -> dict:
     if app.state.pytest_wrp.collect():
         return {"status": Status.COLLECTED}
     return {"status": Status.BUSY}
+
+
+@app.get("/api/status")
+def status() -> dict:
+    """Get pytest subprocess status.
+
+    Returns:
+        dict[str, RunStatus]: run status
+    """
+    is_running = app.state.pytest_wrp.is_running()
+    status = Status.BUSY if is_running else Status.READY
+    return {"status": status}
 
 
 @app.get("/api/couch")

--- a/hardpy/pytest_hardpy/pytest_wrapper.py
+++ b/hardpy/pytest_hardpy/pytest_wrapper.py
@@ -45,6 +45,8 @@ class PyTestWrapper:
                     "pytest",
                     "--hardpy-db-url",
                     self.config.database.connection_url(),
+                    "--hardpy-tests-name",
+                    self.config.tests_name,
                     "--sc-address",
                     self.config.stand_cloud.address,
                     "--sc-connection-only"
@@ -62,6 +64,8 @@ class PyTestWrapper:
                     "pytest",
                     "--hardpy-db-url",
                     self.config.database.connection_url(),
+                    "--hardpy-tests-name",
+                    self.config.tests_name,
                     "--sc-address",
                     self.config.stand_cloud.address,
                     "--sc-connection-only"
@@ -111,6 +115,8 @@ class PyTestWrapper:
             "--collect-only",
             "--hardpy-db-url",
             self.config.database.connection_url(),
+            "--hardpy-tests-name",
+            self.config.tests_name,
             "--hardpy-pt",
         ]
 
@@ -149,3 +155,11 @@ class PyTestWrapper:
             bool | None: True if self._proc is not None
         """
         return self._proc and self._proc.poll() is None
+
+    def get_config(self) -> dict:
+        """Get HardPy configuration.
+
+        Returns:
+            dict: HardPy configuration
+        """
+        return ConfigManager().get_config().model_dump()

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -10,6 +10,7 @@ from hardpy.common.config import (
     StandCloudConfig,
 )
 
+tests_no_default_name = "Tests1"
 db_no_default_user = "dev1"
 db_no_default_password = "dev1"
 db_no_default_host = "localhost1"
@@ -31,6 +32,7 @@ def test_config_manager_init(tmp_path: Path):
     tests_dir = tmp_path / "my_tests"
     ConfigManager.init_config(
         tests_dir=str(tests_dir),
+        tests_name=tests_no_default_name,
         database_user=db_no_default_user,
         database_password=db_no_default_password,
         database_host=db_no_default_host,
@@ -42,6 +44,7 @@ def test_config_manager_init(tmp_path: Path):
     config = ConfigManager.get_config()
     assert isinstance(config, HardpyConfig)
     assert config.tests_dir == str(tests_dir)
+    assert config.tests_name == tests_no_default_name
     assert config.database.user == db_no_default_user
     assert config.database.password == db_no_default_password
     assert config.database.host == db_no_default_host
@@ -80,12 +83,14 @@ def test_hardpy_config():
     config = HardpyConfig(
         title="HardPy TOML config",
         tests_dir="tests",
+        tests_name="tests",
         database=DatabaseConfig(),
         frontend=FrontendConfig(),
         stand_cloud=StandCloudConfig(),
     )
     assert config.title == "HardPy TOML config"
     assert config.tests_dir == "tests"
+    assert config.tests_name == "tests"
     assert config.database.user == db_default_user
     assert config.database.password == db_default_password
     assert config.database.host == db_default_host
@@ -101,6 +106,7 @@ def test_config_manager_create_config(tmp_path: Path):
 
     ConfigManager.init_config(
         tests_dir=str(tests_dir),
+        tests_name=str(tests_dir),
         database_user=db_default_user,
         database_password=db_default_password,
         database_host=db_default_host,
@@ -122,6 +128,7 @@ def test_read_config_success(tmp_path: Path):
     test_config_data = {
         "title": "Test HardPy Config",
         "tests_dir": "my_tests",
+        "tests_name": "My tests",
         "database": {
             "user": db_default_user,
             "password": db_default_password,
@@ -142,6 +149,7 @@ def test_read_config_success(tmp_path: Path):
     assert isinstance(config, HardpyConfig)
     assert config.title == test_config_data["title"]
     assert config.tests_dir == test_config_data["tests_dir"]
+    assert config.tests_name == test_config_data["tests_name"]
     assert config.database.user == test_config_data["database"]["user"]
     assert config.database.password == test_config_data["database"]["password"]
     assert config.database.host == test_config_data["database"]["host"]


### PR DESCRIPTION
## About

### Tests name
Added the `tests_name` field to **hardpy.toml**. The `tests_name` allows to name the test suite in the operator panel. 

**hardpy.toml** file in the minute_parity directory:

```toml
title = "HardPy TOML config"
tests_dir = "minute_parity"
tests_name = "Minute Parity"

...
```

Operator panel with the  name "**Minute Parity**":
![image](https://github.com/user-attachments/assets/44ff3b68-3243-4c3f-b62c-c44d9afb2b26)

### New CLI commands
Added CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. 

* The `hardpy start` command is used to launch **HardPy** tests while the **HardPy** opener panel is running.
* The `hardpy stop` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.
* The `hardpy status` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.