### PR TITLE
Zero module stop time in skip test

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Fix the behavioral with empty module stop time with skipped test.
+  [PR-129](https://github.com/everypinio/hardpy/pull/129)
 * Add the `tests_name` field to **hardpy.toml**.
   The `tests_name` allows to name the test suite in the operator panel. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
 * Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]

--- a/tests/test_plugin/test_dependency.py
+++ b/tests/test_plugin/test_dependency.py
@@ -360,6 +360,160 @@ def test_case_dependency_from_big_module(pytester: Pytester, hardpy_opts: list[s
     result.assert_outcomes(passed=2, failed=1, skipped=3)
 
 
+def test__module_stop_time_first_case_skip(pytester: Pytester, hardpy_opts: list[str]):
+    """Check module stop time.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_stop_time = report.modules["test_1"].stop_time
+            module_start_time = report.modules["test_1"].start_time
+
+            assert module_stop_time >= module_start_time
+
+            case_2_stop_time = report.modules["test_1"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_1"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            assert False
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=0, failed=1, skipped=1)
+
+
+def test_first_case_skip_third_case_pass(pytester: Pytester, hardpy_opts: list[str]):
+    """Check module stop time.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_stop_time = report.modules["test_1"].stop_time
+            module_start_time = report.modules["test_1"].start_time
+
+            assert module_stop_time >= module_start_time
+
+            case_2_stop_time = report.modules["test_1"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_1"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+            case_3_stop_time = report.modules["test_1"].cases["test_three"].stop_time
+            case_3_start_time = report.modules["test_1"].cases["test_three"].start_time
+
+            assert case_3_stop_time >= case_3_start_time
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            assert False
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+
+        def test_three():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=1, failed=1, skipped=1)
+
+
+def test_first_case_user_skip(pytester: Pytester, hardpy_opts: list[str]):
+    """Check stop_time in test skipped by user.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_stop_time = report.modules["test_1"].stop_time
+            module_start_time = report.modules["test_1"].start_time
+
+            assert module_stop_time >= module_start_time
+
+            case_1_stop_time = report.modules["test_1"].cases["test_one"].stop_time
+            case_1_start_time = report.modules["test_1"].cases["test_one"].start_time
+
+            assert case_1_stop_time >= case_1_start_time
+
+            case_2_stop_time = report.modules["test_1"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_1"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            pytest.skip()
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=0, failed=0, skipped=2)
+
+
 def test_module_dependency_from_failed_case(pytester: Pytester, hardpy_opts: list[str]):
     pytester.makepyfile(
         test_1="""


### PR DESCRIPTION
## About

In modules where the final test was dependent on another test and was not executed at the end, the module **stop_time** was not filled in.

### Fixes
1. In cases where the **HardpyPlugin** plugin skips a test, the **start_time** and **stop_time** of the test are not filled. Module  **start_time** and **stop_time** are filled in.
2. In cases where user skip test via a self-call to `pytest.skip()`, the **start_time** and **stop_time** in case and module filled in. 

### Minimal problem example

```python
# test_1.py
import pytest
import hardpy

def test_one():
    assert False

@pytest.mark.dependency("test_1::test_one")
def test_two():
    assert True
```

Problem in the database with **test_1** module **stop_time**:

```json
{
  "_id": "current",
  "_rev": "10484-a5e517416d9b8c0fe7b1fe43d83489f2",
  "modules": {
    "test_1": {
      "status": "skipped",
      "name": "test_1",
      "start_time": 1744812548,
      "stop_time": null,
      "cases": {
        "test_one": {
          "status": "failed",
          "name": "test_one",
          "start_time": 1744812548,
          "stop_time": 1744812548,
          "assertion_msg": "assert False",
          "msg": null,
          "dialog_box": {},
          "attempt": 1
        },
        "test_two": {
          "status": "skipped",
          "name": "test_two",
          "start_time": null,
          "stop_time": null,
          "assertion_msg": null,
          "msg": null,
          "dialog_box": {},
          "attempt": 0
        }
      }
    }
  },
```

Correct database:

```json
{
  "_id": "current",
  "_rev": "10492-8cdc23b5db6306254b8736cd23d6ebbb",
  "modules": {
    "test_1": {
      "status": "failed",
      "name": "test_1",
      "start_time": 1744812725,
      "stop_time": 1744812725,
      "cases": {
        "test_one": {
          "status": "failed",
          "name": "test_one",
          "start_time": 1744812725,
          "stop_time": 1744812725,
          "assertion_msg": "assert False",
          "msg": null,
          "dialog_box": {},
          "attempt": 1
        },
        "test_two": {
          "status": "skipped",
          "name": "test_two",
          "start_time": null,
          "stop_time": null,
          "assertion_msg": "Skipped: Test test_1.py::test_two is skipped",
          "msg": null,
          "dialog_box": {},
          "attempt": 0
        }
      }
    }
  },
```

### Good behavioral example

```python
# test_1.py
import pytest
import hardpy

def test_one():
    assert False

@pytest.mark.dependency("test_1::test_one")
def test_two():
    assert True

def test_three():
    assert True
```

### Self-call skip behavioral example

```python
# test_1.py
import pytest
import hardpy

def test_one():
    pytest.skip()

@pytest.mark.dependency("test_1::test_one")
def test_two():
    assert True
```

Database from self-skipped example:

```json
{
  "_id": "current",
  "_rev": "10508-cf4c40e4aa603d209ef1240f6814ff60",
  "modules": {
    "test_1": {
      "status": "skipped",
      "name": "test_1",
      "start_time": 1744812848,
      "stop_time": 1744812848,
      "cases": {
        "test_one": {
          "status": "skipped",
          "name": "test_one",
          "start_time": 1744812848,
          "stop_time": 1744812848,
          "assertion_msg": "Skipped",
          "msg": null,
          "dialog_box": {},
          "attempt": 1
        },
        "test_two": {
          "status": "skipped",
          "name": "test_two",
          "start_time": null,
          "stop_time": null,
          "assertion_msg": "Skipped: Test test_1.py::test_two is skipped",
          "msg": null,
          "dialog_box": {},
          "attempt": 0
        }
      }
    }
  },
```
