### PR TITLE
0.11.1-rc1

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -74,8 +74,6 @@ indent-width = 4
             "BLE001"  # bare except
         ]
         "hardpy/cli/template.py" = ["D102"]
-        "hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py" = ["B904"] # raise ... from err
-        "hardpy/common/stand_cloud/connector.py" = ["B904"] # raise ... from err
         "hardpy/common/stand_cloud/registration.py" = [
             "T201",     # using print
             "E501"      # enable long lines

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -70,7 +70,8 @@ indent-width = 4
         ]
         "hardpy/cli/cli.py" = [
             "T201",   # using print
-            "UP007"   # Non PEP 604 annotation
+            "UP007",  # Non PEP 604 annotation
+            "BLE001"  # bare except
         ]
         "hardpy/cli/template.py" = ["D102"]
         "hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py" = ["B904"] # raise ... from err

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,39 @@
             ]
         },
         {
+            "name": "HardPy: Start template",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "hardpy.cli.cli",
+            "console": "integratedTerminal",
+            "args": [
+                "start",
+                "examples/template"
+            ]
+        },
+        {
+            "name": "HardPy: Stop template",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "hardpy.cli.cli",
+            "console": "integratedTerminal",
+            "args": [
+                "stop",
+                "examples/template"
+            ]
+        },
+        {
+            "name": "HardPy: Status template",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "hardpy.cli.cli",
+            "console": "integratedTerminal",
+            "args": [
+                "status",
+                "examples/template"
+            ]
+        },
+        {
             "name": "StandCloud login",
             "type": "debugpy",
             "request": "launch",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,13 +2,25 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
-* Add Stand info to Operator panel. [[PR-127](https://github.com/everypinio/hardpy/pull/127)]
-* Fix the behavioral with empty module stop time with skipped test.
+## HardPy 0.11.1
+
+* Change **StandCloud** URL for publish test report to `/test_report`.
+  [PR-131](https://github.com/everypinio/hardpy/pull/131)
+* Add `StandCloudReader` class for reading data from **StandCloud**.
+  [PR-131](https://github.com/everypinio/hardpy/pull/131)
+* Fix the behavior with empty module start time with skipped test.
+  [PR-131](https://github.com/everypinio/hardpy/pull/131)
+* Fix the behavior with empty module stop time with skipped test.
   [PR-129](https://github.com/everypinio/hardpy/pull/129)
+* Add Stand info to Operator panel.
+  [[PR-127](https://github.com/everypinio/hardpy/pull/127)]
 * Add the `tests_name` field to **hardpy.toml**.
-  The `tests_name` allows to name the test suite in the operator panel. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
-* Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
-* Change the StandCloud API address to `/hardpy/api`. [[PR-125](https://github.com/everypinio/hardpy/pull/125)]
+  The `tests_name` allows to name the test suite in the operator panel.
+  [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
+* Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`.
+  [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
+* Change the StandCloud API address to `/hardpy/api`.
+  [[PR-125](https://github.com/everypinio/hardpy/pull/125)]
 
 ## HardPy 0.11.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Add Stand info to Operator panel. [[PR-127](https://github.com/everypinio/hardpy/pull/127)]
 * Fix the behavioral with empty module stop time with skipped test.
   [PR-129](https://github.com/everypinio/hardpy/pull/129)
 * Add the `tests_name` field to **hardpy.toml**.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Fix the behavioral with empty module stop time with skipped test.
+  [PR-129](https://github.com/everypinio/hardpy/pull/129)
 * Add the `tests_name` field to **hardpy.toml**.
   The `tests_name` allows to name the test suite in the operator panel. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
 * Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,13 +5,13 @@ Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<pa
 ## HardPy 0.11.1
 
 * Change **StandCloud** URL for publish test report to `/test_report`.
-  [PR-131](https://github.com/everypinio/hardpy/pull/131)
+  [[PR-131](https://github.com/everypinio/hardpy/pull/131)]
 * Add `StandCloudReader` class for reading data from **StandCloud**.
-  [PR-131](https://github.com/everypinio/hardpy/pull/131)
+  [[PR-131](https://github.com/everypinio/hardpy/pull/131)]
 * Fix the behavior with empty module start time with skipped test.
-  [PR-131](https://github.com/everypinio/hardpy/pull/131)
+  [[PR-131](https://github.com/everypinio/hardpy/pull/131)]
 * Fix the behavior with empty module stop time with skipped test.
-  [PR-129](https://github.com/everypinio/hardpy/pull/129)
+  [[PR-129](https://github.com/everypinio/hardpy/pull/129)]
 * Add Stand info to Operator panel.
   [[PR-127](https://github.com/everypinio/hardpy/pull/127)]
 * Add the `tests_name` field to **hardpy.toml**.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Add the `tests_name` field to **hardpy.toml**.
+  The `tests_name` allows to name the test suite in the operator panel. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
+* Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
+* Change the StandCloud API address to `/hardpy/api`. [[PR-125](https://github.com/everypinio/hardpy/pull/125)]
+
 ## HardPy 0.11.0
 
 * Remove the internal **HardPy** socket on port 6525. Pytest plugin arguments `--hardpy-sh` and `--hardpy-sp`

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -124,8 +124,7 @@ By default, it stops tests in the current directory.
 
 ## hardpy status
 
-The `hardpy status` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.
-By default, it stops tests in the current directory.
+The `hardpy status` command is used to get **HardPy** tests launch status.
 
 ```bash
  Usage: hardpy status [OPTIONS] [TESTS_DIR]

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -37,6 +37,7 @@ More info in [hardpy config](./hardpy_config.md).
 │   tests_dir      [TESTS_DIR]  [default: None]                                                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --tests-name                                   TEXT     Specify a tests suite name.                        │
 │ --create-database      --no-create-database             Create CouchDB database.                           │
 │                                                         [default: create-database]                         │
 │ --database-user                                TEXT     Specify a database user. [default: dev]            │
@@ -83,6 +84,60 @@ To obtain this information, use:
 
 ```bash
 hardpy run --help
+```
+
+## hardpy start
+
+The `hardpy start` command is used to launch **HardPy** tests while the **HardPy** opener panel is running.
+By default, it starts tests in the current directory.
+
+```bash
+ Usage: hardpy start [OPTIONS] [TESTS_DIR]
+
+ Start HardPy tests.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────╮
+│   tests_dir      [TESTS_DIR]  [default: None]                                                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## hardpy stop
+
+The `hardpy stop` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.
+By default, it stops tests in the current directory.
+
+```bash
+ Usage: hardpy stop [OPTIONS] [TESTS_DIR]
+
+ Stop HardPy tests.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────╮
+│   tests_dir      [TESTS_DIR]  [default: None]                                                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## hardpy status
+
+The `hardpy status` command is used to stop **HardPy** tests while the **HardPy** opener panel is running.
+By default, it stops tests in the current directory.
+
+```bash
+ Usage: hardpy status [OPTIONS] [TESTS_DIR]
+
+ Get HardPy test launch status.
+
+╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────╮
+│   tests_dir      [TESTS_DIR]  [default: None]                                                              │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## sc-login

--- a/docs/documentation/hardpy_config.md
+++ b/docs/documentation/hardpy_config.md
@@ -23,6 +23,28 @@ host = "localhost"
 port = 8000
 ```
 
+## Maximum configuration file
+
+```toml
+title = "HardPy TOML config"
+tests_dir = "tests"
+tests_name = "My tests"
+
+[database]
+user = "dev"
+password = "dev"
+host = "localhost"
+port = 5984
+
+[frontend]
+host = "localhost"
+port = 8000
+
+[stand_cloud]
+address = "demo.standcloud.io"
+connection_only = true
+```
+
 ## Configuration fields description
 
 ### common
@@ -38,6 +60,11 @@ The value is always `HardPy TOML config`.
 
 Tests directory. The default is `tests`.
 The user can change this value with the `hardpy init` argument.
+
+#### tests_name
+
+Tests name. The default is [tests_dir](#tests_dir).
+The user can change this value with the `hardpy init --tests-name` argument.
 
 ### database
 

--- a/docs/documentation/hardpy_panel.md
+++ b/docs/documentation/hardpy_panel.md
@@ -34,6 +34,21 @@ the pytest launcher (in a terminal or from another application).
 The operator panel contains a test start/stop button in the lower right corner of the screen.
 The user can start/stop tests using the space key.
 
+### Operator panel bar
+
+Operator panel bar displays key system status information in a compact tag-based format.
+
+**Fields:**
+
+- **Stand name** - Name of the test stand (from `db_state.test_stand.name`)  
+- **Status** - Current system status (from `db_state.status`)  
+- **Start time** - Test/operation start timestamp with timezone  
+- **Finish time** - Completion timestamp with timezone  
+- **Alert** - Active warning or error message  
+- **Test stand info** - Additional parameters from test stand configuration (dynamic key-value pairs)  
+
+All fields appear as minimal tags and only display when data is available.
+
 ### Settings
 
 The operator panel contains a setting button in the top right corner.

--- a/docs/documentation/hardpy_panel.md
+++ b/docs/documentation/hardpy_panel.md
@@ -40,12 +40,13 @@ Operator panel bar displays key system status information in a compact tag-based
 
 **Fields:**
 
-- **Stand name** - Name of the test stand (from `db_state.test_stand.name`)  
-- **Status** - Current system status (from `db_state.status`)  
-- **Start time** - Test/operation start timestamp with timezone  
-- **Finish time** - Completion timestamp with timezone  
-- **Alert** - Active warning or error message  
-- **Test stand info** - Additional parameters from test stand configuration (dynamic key-value pairs)  
+- **Stand name** - name of the test stand;
+- **Status** - current system status;
+- **Start time** - test/operation start timestamp with timezone;
+- **Finish time** - completion timestamp with timezone;
+- **Alert** - active warning or error message;
+- **Test stand info** - additional test stand parameters
+  from [set_dut_info](./pytest_hardpy.md#set_dut_info) info;
 
 All fields appear as minimal tags and only display when data is available.
 
@@ -55,14 +56,14 @@ The operator panel contains a setting button in the top right corner.
 
 #### debug mode
 
-The user can view the **statestore** database online by clicking on 
+The user can view the **statestore** database online by clicking on
 the **Turn on the debug mode** button.
 
 Debug mode is disabled by default.
 
 #### sound
 
-The user can turn on the sound of the end of the test by clicking on 
+The user can turn on the sound of the end of the test by clicking on
 the **Turn on the sound** button.
 
 Sound is disabled by default.
@@ -216,10 +217,10 @@ Allows steps with text and image.
 
 ### Operator message
 
-The messages to the operator are similar to [dialog boxes](#dialog-box), 
-but do not contain a **Confirm** button and can be called outside 
-the execution of the test plan, for example in case of exception 
-catching in the `conftest.py` file. 
+The messages to the operator are similar to [dialog boxes](#dialog-box),
+but do not contain a **Confirm** button and can be called outside
+the execution of the test plan, for example in case of exception
+catching in the `conftest.py` file.
 For more information, see the example [operator message](./../examples/operator_msg.md)
 or in the function description [set_operator_message](./pytest_hardpy.md#set_operator_message).
 

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -559,6 +559,7 @@ def fill_actions_after_test(post_run_functions: list):
 #### StandCloudLoader
 
 Used to write reports to the **StandCloud**.
+A login to **StandCloud** is required to work.
 
 **Arguments:**
 
@@ -595,6 +596,54 @@ def finish_executing():
 def fill_actions_after_test(post_run_functions: list):
     post_run_functions.append(finish_executing)
     yield
+```
+
+#### StandCloudConnector
+
+Used to create the **StandCloud** connection addresses.
+
+**Arguments:**
+
+- `addr` *(str)*: StandCloud service name.
+  For example: **demo.standcloud.io**
+- `api_mode` *(StandCloudAPIMode)*: StandCloud API mode:
+  **hardpy** for test stand, **integration** for third-party service.
+  Default: `StandCloudAPIMode.HARDPY`
+- `api_version` *(int)*: StandCloud API version.
+  Default: 1.
+
+#### StandCloudReader
+
+Used to read data from the **StandCloud**.
+A login to **StandCloud** is required to work.
+For more information, see the example [StandCloud reader](./../examples/stand_cloud_reader.md)
+
+**Arguments:**
+
+- `sc_connector` ([StandCloudConnector](#standcloudconnector)): **StandCloud** connection data.
+
+**Functions:**
+
+- `test_run` *(run_id: str)* - get run data from `/test_run` endpoint.
+  Return `requests.Response` class with test run data.
+- `tested_dut` *(params: dict[str, Any])* - get tested DUT's data from `/tested_dut` endpoint.
+  All tested dut's filters can view in REST documentation.
+
+**Examples:**
+
+```python
+    reader = StandCloudReader(StandCloudConnector(addr="demo.standcloud.io"))
+
+    response = reader.test_run("0196434d-e8f7-7ce1-81f7-e16f20487494")
+    status_code = response.status_code
+    response_data = response.json()
+    print(response_data)
+
+    param = {"part_number": "part_number_1", "status": "pass", "firmware_version": "1.2.3"}
+    response = reader.tested_dut(param)
+    status_code = response.status_code
+    response_data = response.json()
+    print(response_data)
 ```
 
 ## Fixture

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -702,6 +702,15 @@ The default is `http://dev:dev@localhost:5984/`.
 --hardpy-db-url
 ```
 
+#### hardpy-tests-name
+
+The **HardPy** tests name.
+The default value is **Tests**.
+
+```bash
+--hardpy-tests-name
+```
+
 #### hardpy-clear-database
 
 Option to clean **statestore** and **runstore** databases before running pytest.

--- a/docs/documentation/stand_cloud.md
+++ b/docs/documentation/stand_cloud.md
@@ -12,9 +12,11 @@ For more information, visit the **StandCloud** [website](https://everypin.io/sta
 
 ## StandCloud and HardPy integration
 
-**HardPy** allows test result data to be stored in the **StandCloud**.
+**HardPy** allows test result data to be stored in the **StandCloud** and
+read them from the **StandCloud**.
 For an example of StandCloud and HardPy integration,
-see [StandCloud example](../examples/stand_cloud.md).
+see [StandCloud example](../examples/stand_cloud.md) and
+[StandCloud readed example](../examples/stand_cloud_reader.md).
 
 To authorize in **StandCloud** you need to know the address of your **StandCloud** service.
 To obtain one, contact **info@everypin.io**.

--- a/docs/examples/hardpy_launch.md
+++ b/docs/examples/hardpy_launch.md
@@ -1,6 +1,6 @@
 # HardPy launch
 
-**HardPy** can be started from either the operator panel or the terminal. 
+**HardPy** can be started from either the operator panel or the terminal.
 Below we will look at all the launch options.
 
 ### how to start
@@ -15,32 +15,43 @@ Initialize the **HardPy** project:
 #### 1. Operator panel
 
 1. Launch operator panel:
-   ```
+   ```bash
    hardpy run test_project
    ```
 2. Open the operator panel in your browser at: [http://localhost:8000/](http://localhost:8000/).
 3. Click the **Start** button.
 
-#### 2. Pytest in console
+#### 2. Start command
+
+1. Launch operator panel:
+   ```bash
+   hardpy run test_project
+   ```
+2. Run the tests by executing the following command in the terminal:
+    ```bash
+    hardpy start test_project
+    ```
+
+#### 3. Pytest in console
 
 Run the tests by executing the following command in the terminal:
 
-```
+```bash
 pytest test_project
 ```
 
-##### 2.1. Pytest in console with launching operator panel
+##### 3.1. Pytest in console with launching operator panel
 
 If the operator panel is running, the tests will start after the command in the terminal in the same way as by clicking on the `Start` button.
 
-##### 2.2. Pytest in console without launching operator panel
+##### 3.2. Pytest in console without launching operator panel
 
 If the operator panel has not been started, the tests will also run, but without visualization.
 
 ???+ warning
     This method is only appropriate if you are not using any operator panel features such as operator messages and dialog boxes.
 
-#### 3. IDE
+#### 4. IDE
 
 An example of starting in vscode is as follows.
 If you use other IDEs, explore the possibility of running tests in your environment.
@@ -48,11 +59,11 @@ If you use other IDEs, explore the possibility of running tests in your environm
 1. Open the [Testing](https://code.visualstudio.com/docs/editor/testing) extension in VS Code.
 2. Run the tests through the extension interface.
 
-##### 3.1. Pytest in Testing with launching operator panel
+##### 4.1. Pytest in Testing with launching operator panel
 
 If the operator panel is running, the tests will start after launching in Testing in the same way as by clicking on the `Start` button.
 
-##### 3.2. Pytest in Testing without launching operator panel
+##### 4.2. Pytest in Testing without launching operator panel
 
 If the operator panel has not been started, the tests will also run, but without visualization.
 

--- a/docs/examples/minute_parity.md
+++ b/docs/examples/minute_parity.md
@@ -112,6 +112,7 @@ def test_stand_info(module_log: logging.Logger):
     hardpy.set_stand_location("Moon")
     info = {
         "some_info": "123",
+        "release": "1.0.0"
     }
     hardpy.set_stand_info(info)
     assert True

--- a/docs/examples/stand_cloud_reader.md
+++ b/docs/examples/stand_cloud_reader.md
@@ -1,0 +1,165 @@
+# StandCloud reader
+
+**HardPy** allows you to read test data from the **StandCloud**.
+For this purpose, the [StandCloudReader](./../documentation/pytest_hardpy.md#standcloudreader)
+class is available in **HardPy**, which provides access to the REST API of the **StandCloud** service.
+To read data from the **StandCloud**, the user must log in to the **StandCloud**
+using the [hardpy sc-login](./../documentation/cli.md#sc-login).
+
+To view the REST API documentation, the user can navigate to the format page
+https://service_name/integration/api/v1/docs,
+where `service_name` is the address of the **StandCloud** client.
+
+Example of documentation page address: https://demo.standcloud.io/integration/api/v1/docs
+
+To access **StandCloud**, contact **info@everypin.io**.
+
+## Functions
+
+### test_run
+
+Allows the user to retrieve data about a specific test run by its id from `/test_run` URL.
+User can get id from [StandCloudLoader.load()](./../documentation/pytest_hardpy.md#standcloudloader)
+function.
+
+**Example:**
+
+```python
+import hardpy
+
+sc_connector = hardpy.StandCloudConnector(addr="demo.standcloud.io")
+reader = hardpy.StandCloudReader(sc_connector)
+
+response = reader.test_run("0196434d-e8f7-7ce1-81f7-e16f20487494")
+print(response.json())
+```
+
+Request URL of this example:
+
+```bash
+https://demo.standcloud.io/hardpy/api/v1/test_run/0196434d-e8f7-7ce1-81f7-e16f20487494
+```
+
+REST API documentation page of this example:
+
+```bash
+https://demo.standcloud.io/integration/api/v1/docs
+```
+
+**Response data example:**
+
+```json
+{
+  "test_run_id": "0196434d-e8f7-7ce1-81f7-e16f20487494",
+  "test_plan_name": "Test Plan A",
+  "serial_number": "SN-98765",
+  "part_number": "PN-54321AB",
+  "status": "FAIL",
+  "status_icon": "❌",
+  "number_of_attempt": 1,
+  "start_time": "2024-02-20T14:23:45Z",
+  "stop_time": "2024-02-20T14:23:45Z",
+  "duration": "00:12:34",
+  "test_stand_name": "EMC Chamber #2",
+  "test_stand_hw_id": "TS-CH45",
+  "test_run_artifact": {
+    "test_run_parameter": "test_run_value"
+  },
+  "test_stand_info": {
+    "calibration_date": "2025-01-15"
+  },
+  "dut_info": {
+    "serial_number": "SN-98765",
+    "part_number": "PN-54321AB",
+    "info": {
+      "manufacturer": "ABC Corp"
+    }
+  }
+}
+```
+
+### tested_dut
+
+Allows the user to retrieve data about a tested dut's by filters from `/tested_dut` URL.
+Filters are specified as parameters. A special place is occupied by the filter by field `dut.info`,
+which allows to add fields `dut.info` as keys for the filter in the parameters.
+
+**Example:**
+
+```python
+import hardpy
+
+sc_connector = hardpy.StandCloudConnector(addr="demo.standcloud.io")
+reader = hardpy.StandCloudReader(sc_connector)
+
+param = {
+    "part_number": "PN-54321AB",
+    "status": "pass",
+    "manufacturer": "ABC_Corp",
+}
+response = reader.tested_dut(param)
+print(response.json())
+```
+
+Request URL of this example:
+
+```bash
+https://demo.standcloud.io/hardpy/api/v1/tested_dut?part_number=PN-54321AB&status=pass&manufacturer=ABC_Corp
+```
+
+REST API documentation page of this example:
+
+```bash
+https://demo.standcloud.io/integration/api/v1/docs
+```
+
+**Response data example:**
+
+```json
+[
+  {
+    "test_plan_name": "Test run #A",
+    "serial_number": "SN-12345",
+    "part_number": "PN-54321AB",
+    "status": "pass",
+    "status_icon": "✅",
+    "attempt_count": 1,
+    "start_time": "2025-03-28T09:34:05Z",
+    "finish_time": "2025-03-28T09:34:55Z",
+    "duration": "PT50S",
+    "test_stand_name": "EMC Chamber #2",
+    "test_stand_hw_id": "TS-CH45",
+    "dut_info": {
+      "manufacturer": "ABC_Corp"
+    },
+    "test_stand_info": {
+      "calibration_date": "2025-01-15"
+    },
+    "test_run_artifact": {
+      "test_run_parameter": "test_run_value"
+    }
+  },
+  {
+    "test_plan_name": "Test run #B",
+    "serial_number": "SN-98766",
+    "part_number": "PN-54321AB",
+    "status": "pass",
+    "status_icon": "✅",
+    "attempt_count": 1,
+    "start_time": "2025-03-28T09:35:05Z",
+    "finish_time": "2025-03-28T09:35:55Z",
+    "duration": "PT50S",
+    "test_stand_name": "EMC Chamber #2",
+    "test_stand_hw_id": "TS-CH45",
+    "dut_info": {
+      "manufacturer": "ABC_Corp"
+    },
+    "test_stand_info": {
+      "calibration_date": "2025-01-15"
+    },
+    "test_run_artifact": {
+      "test_run_parameter": "test_run_value"
+    }
+  }
+]
+```

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -21,13 +21,18 @@ Alternatively, the user can start the operator panel with the “Start” button
 python -m pytest
 ```
 
-The user can also run tests without the operator panel, just through pytest.
-This method may be appropriate if the user does not need the operator panel.
+The user can also run tests without the operator panel, just using the `hardpy start` command or
+using `pytest`.
 
 ## Stopping the tests
 
-The user can stop the tests during execution from the operator panel by clicking on the **Stop** button.
+The user can stop the tests during execution from the operator panel by clicking on the **Stop** button
+or using the `hardpy stop` command.
 It is possible to stop tests from the console by sending an interrupt, e.g. “Ctrl-C” in Linux.
+
+## Checking the status of tests
+
+The user can check the status of tests using the `hardpy status` command.
 
 ## Storing test result in database
 

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -3,6 +3,7 @@
 ## Viewing tests in the operator panel
 
 The operator panel allows you to view the test hierarchy with **test folder/test file/function** levels.
+See the [HardPy panel](./../documentation/hardpy_panel.md) for more information.
 User can launch operator panel using [hardpy run](./../documentation/cli.md#hardpy-run) command.
 
 ## Running tests
@@ -98,6 +99,11 @@ The startup is described in the [Multiple Stand](./../examples/multiple_stands.m
 
 ## Storing test result to StandCloud
 
-**HardPy** allows you to send test results to **StandCloud**, a data storage and analysis platform.
+**HardPy** allows user to send test results to **StandCloud**, a data storage and analysis platform.
 See the [StandCloud](./../documentation/stand_cloud.md) section and the
 [StandCloud example](./../examples/stand_cloud.md) for more information.
+
+## Reading test result from StandCloud
+
+**HardPy** allows user to read test result from **StandCloud**.
+See the [StandCloud reader](./../examples/stand_cloud_reader.md) for more information.

--- a/examples/minute_parity/test_1.py
+++ b/examples/minute_parity/test_1.py
@@ -30,6 +30,7 @@ def test_stand_info(module_log: logging.Logger):
     hardpy.set_stand_location("Moon")
     info = {
         "some_info": "123",
+        "release": "1.0.0",
     }
     hardpy.set_stand_info(info)
     assert True

--- a/hardpy/__init__.py
+++ b/hardpy/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Everypin
 # GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from hardpy.common.stand_cloud import StandCloudError
+from hardpy.common.stand_cloud import StandCloudConnector, StandCloudError
 from hardpy.pytest_hardpy.pytest_call import (
     clear_operator_message,
     get_current_attempt,
@@ -20,7 +20,11 @@ from hardpy.pytest_hardpy.pytest_call import (
     set_stand_location,
     set_stand_name,
 )
-from hardpy.pytest_hardpy.result import CouchdbLoader, StandCloudLoader
+from hardpy.pytest_hardpy.result import (
+    CouchdbLoader,
+    StandCloudLoader,
+    StandCloudReader,
+)
 from hardpy.pytest_hardpy.result.couchdb_config import CouchdbConfig
 from hardpy.pytest_hardpy.utils import (
     BaseWidget,
@@ -54,8 +58,10 @@ __all__ = [
     "MultistepWidget",
     "NumericInputWidget",
     "RadiobuttonWidget",
+    "StandCloudConnector",
     "StandCloudError",
     "StandCloudLoader",
+    "StandCloudReader",
     "StepWidget",
     "TextInputWidget",
     "clear_operator_message",

--- a/hardpy/common/config.py
+++ b/hardpy/common/config.py
@@ -57,6 +57,7 @@ class HardpyConfig(BaseModel, extra="allow"):
 
     title: str = "HardPy TOML config"
     tests_dir: str = "tests"
+    tests_name: str = ""
     database: DatabaseConfig = DatabaseConfig()
     frontend: FrontendConfig = FrontendConfig()
     stand_cloud: StandCloudConfig = StandCloudConfig()
@@ -72,6 +73,7 @@ class ConfigManager:
     def init_config(  # noqa: PLR0913
         cls,
         tests_dir: str,
+        tests_name: str,
         database_user: str,
         database_password: str,
         database_host: str,
@@ -85,6 +87,7 @@ class ConfigManager:
 
         Args:
             tests_dir (str): Tests directory.
+            tests_name (str): Tests suite name.
             database_user (str): Database user name.
             database_password (str): Database password.
             database_host (str): Database host.
@@ -95,6 +98,7 @@ class ConfigManager:
             sc_connection_only (bool): StandCloud check availability.
         """
         cls.obj.tests_dir = str(tests_dir)
+        cls.obj.tests_name = tests_name
         cls.obj.database.user = database_user
         cls.obj.database.password = database_password
         cls.obj.database.host = database_host
@@ -113,6 +117,8 @@ class ConfigManager:
         """
         if not cls.obj.stand_cloud.address:
             del cls.obj.stand_cloud
+        if not cls.obj.tests_name:
+            del cls.obj.tests_name
         config_str = tomli_w.dumps(cls.obj.model_dump())
         with Path.open(parent_dir / "hardpy.toml", "w") as file:
             file.write(config_str)

--- a/hardpy/common/stand_cloud/__init__.py
+++ b/hardpy/common/stand_cloud/__init__.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2024 Everypin
 # GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from hardpy.common.stand_cloud.connector import StandCloudConnector
+from hardpy.common.stand_cloud.connector import StandCloudAPIMode, StandCloudConnector
 from hardpy.common.stand_cloud.exception import StandCloudError
 from hardpy.common.stand_cloud.registration import login, logout
 
 __all__ = [
+    "StandCloudAPIMode",
     "StandCloudConnector",
     "StandCloudError",
     "login",

--- a/hardpy/common/stand_cloud/connector.py
+++ b/hardpy/common/stand_cloud/connector.py
@@ -59,7 +59,7 @@ class StandCloudConnector:
         auth_addr = addr + "/auth"
 
         self._url: StandCloudURL = StandCloudURL(
-            api=https_prefix + addr + self._get_service_name(addr) + "/api/v1",
+            api=https_prefix + addr + "/hardpy/api/v1",
             token=https_prefix + auth_addr + "/api/oidc/token",
             par=https_prefix + auth_addr + "/api/oidc/pushed-authorization-request",
             auth=https_prefix + auth_addr + "/api/oidc/authorization",
@@ -216,12 +216,3 @@ class StandCloudConnector:
             expires_at=expires_at,
             expires_in=expires_in,
         )
-
-    def _get_service_name(self, addr: str) -> str:
-        addr_parts = addr.split(".")
-        number_of_parts = 3
-        service_position_in_address = 1
-        if isinstance(addr_parts, list) and len(addr_parts) >= number_of_parts:
-            return "/" + addr_parts[service_position_in_address]
-        msg = f"Invalid StandCloud address: {addr}"
-        raise StandCloudError(msg)

--- a/hardpy/common/stand_cloud/connector.py
+++ b/hardpy/common/stand_cloud/connector.py
@@ -4,19 +4,12 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from logging import getLogger
 from typing import TYPE_CHECKING, NamedTuple
 
-from oauthlib.oauth2.rfc6749.errors import (
-    InvalidGrantError,
-    MissingTokenError,
-    TokenExpiredError,
-)
-from requests.exceptions import (
-    ConnectionError as RequestConnectionError,
-    HTTPError,
-    InvalidURL,
-)
+from oauthlib.oauth2.rfc6749.errors import OAuth2Error
+from requests.exceptions import RequestException
 from requests_oauth2client import ApiClient, BearerToken
 from requests_oauth2client.tokens import ExpiredAccessToken
 from requests_oauthlib import OAuth2Session
@@ -42,24 +35,41 @@ class StandCloudURL(NamedTuple):
     par: str
     auth: str
 
+
+class StandCloudAPIMode(str, Enum):
+    """StandCloud API mode.
+
+    HARDPY for test stand, integration for third-party service.
+    """
+
+    HARDPY = "hardpy"
+    INTEGRATION = "integration"
+
+
 class StandCloudConnector:
     """StandCloud API connector."""
 
     def __init__(
         self,
         addr: str,
+        api_mode: StandCloudAPIMode = StandCloudAPIMode.HARDPY,
+        api_version: int = 1,
     ) -> None:
         """Create StandCLoud loader.
 
         Args:
-            addr (str | None, optional): StandCloud address.
-            The option only for development and debug. Defaults to True.
+            addr (str): StandCloud service name.
+            api_mode (StandCloudAPIMode): StandCloud API mode,
+                hardpy for test stand, integration for third-party service.
+                Default: StandCloudAPIMode.HARDPY.
+            api_version (int): StandCloud API version.
+                Default: 1.
         """
         https_prefix = "https://"
         auth_addr = addr + "/auth"
 
         self._url: StandCloudURL = StandCloudURL(
-            api=https_prefix + addr + "/hardpy/api/v1",
+            api=https_prefix + addr + f"/{api_mode}/api/v{api_version}",
             token=https_prefix + auth_addr + "/api/oidc/token",
             par=https_prefix + auth_addr + "/api/oidc/pushed-authorization-request",
             auth=https_prefix + auth_addr + "/api/oidc/authorization",
@@ -98,13 +108,11 @@ class StandCloudConnector:
         try:
             resp = api.get(verify=self._verify_ssl)
         except ExpiredAccessToken as exc:
-            raise StandCloudError(str(exc))
-        except TokenExpiredError as exc:
-            raise StandCloudError(exc.description)
-        except InvalidGrantError as exc:
-            raise StandCloudError(exc.description)
-        except HTTPError as exc:
-            raise StandCloudError(exc.strerror)  # type: ignore
+            raise StandCloudError(str(exc)) from exc
+        except OAuth2Error as exc:
+            raise StandCloudError(exc.description) from exc
+        except RequestException as exc:
+            raise StandCloudError(exc.strerror) from exc # type: ignore
 
         return resp
 
@@ -192,15 +200,10 @@ class StandCloudConnector:
                     verify=False,
                     **extra,
                 )
-            except InvalidGrantError as exc:
-                raise StandCloudError(exc.description)
-            except RequestConnectionError as exc:
-                raise StandCloudError(exc.strerror)  # type: ignore
-            except MissingTokenError as exc:
-                raise StandCloudError(exc.description)
-            except InvalidURL:
-                msg = "Authentication URL is not available"
-                raise StandCloudError(msg)
+            except OAuth2Error as exc:
+                raise StandCloudError(exc.description) from exc
+            except RequestException as exc:
+                raise StandCloudError(exc.strerror) from exc  # type: ignore
             self._token_update(ret)  # type: ignore
 
         return ApiClient(self._url.api + "/" + endpoint, session=session, timeout=10)

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -18,9 +18,9 @@ app.state.pytest_wrp = PyTestWrapper()
 
 
 class Status(str, Enum):
-    """Pytest run status.
+    """HardPy status.
 
-    Statuses, that can be returned by HardPy to frontend.
+    Statuses, that can be returned by HardPy API.
     """
 
     STOPPED = "stopped"
@@ -29,6 +29,16 @@ class Status(str, Enum):
     BUSY = "busy"
     READY = "ready"
     ERROR = "error"
+
+
+@app.get("/api/hardpy_config")
+def hardpy_config() -> dict:
+    """Get config of HardPy.
+
+    Returns:
+        dict: HardPy config
+    """
+    return app.state.pytest_wrp.get_config()
 
 
 @app.get("/api/start")
@@ -66,6 +76,18 @@ def collect_pytest() -> dict:
     if app.state.pytest_wrp.collect():
         return {"status": Status.COLLECTED}
     return {"status": Status.BUSY}
+
+
+@app.get("/api/status")
+def status() -> dict:
+    """Get pytest subprocess status.
+
+    Returns:
+        dict[str, RunStatus]: run status
+    """
+    is_running = app.state.pytest_wrp.is_running()
+    status = Status.BUSY if is_running else Status.READY
+    return {"status": status}
 
 
 @app.get("/api/couch")

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/SuiteList.tsx
@@ -20,6 +20,7 @@ interface Suite {
 
 interface TestStand {
   name: string;
+  info: Record<string, unknown>;
 }
 
 interface DriversInfo {
@@ -154,6 +155,15 @@ export class SuiteList extends React.Component<Props> {
             <Tag minimal style={TAG_ELEMENT_STYLE}>
               Alert: {alert}
             </Tag>
+          )}
+          {db_state.test_stand?.info && Object.keys(db_state.test_stand.info).length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '5px' }}>
+              {Object.entries(db_state.test_stand.info).map(([key, value]) => (
+                <Tag key={key} minimal style={TAG_ELEMENT_STYLE}>
+                  Test stand {key}: {typeof value === 'string' ? value : JSON.stringify(value)}
+                </Tag>
+              ))}
+            </div>
           )}
           <Divider />
           {_.map([...module_names], (name: string, index: number) =>

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -268,8 +268,8 @@ class HardpyPlugin:
 
         status = TestStatus.RUN
         is_skip_test = self._is_skip_test(node_info)
+        self._reporter.set_module_start_time(node_info.module_id)
         if not is_skip_test:
-            self._reporter.set_module_start_time(node_info.module_id)
             self._reporter.set_case_start_time(node_info.module_id, node_info.case_id)
         else:
             status = TestStatus.SKIPPED

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -328,7 +328,11 @@ class HardpyPlugin:
 
     def pytest_runtest_logreport(self, report: TestReport) -> bool | None:
         """Call after call of each test item."""
-        if report.when != "call" and report.failed is False:
+        is_skipped_by_plugin: bool = False
+        if report.when == "setup" and report.skipped is True:
+            # plugin-skipped tests should not have start and stop times
+            is_skipped_by_plugin = True
+        elif report.when != "call" and report.failed is False:
             # ignore setup and teardown phase or continue processing setup
             # and teardown failure (fixture exception handler)
             return True
@@ -341,10 +345,9 @@ class HardpyPlugin:
             case_id,
             TestStatus(report.outcome),
         )
-        self._reporter.set_case_stop_time(
-            module_id,
-            case_id,
-        )
+        # update case stop_time in non-skipped tests or user-skipped tests
+        if report.skipped is False or is_skipped_by_plugin is False:
+            self._reporter.set_case_stop_time(module_id, case_id)
 
         assertion_msg = self._decode_assertion_msg(report.longrepr)
         self._reporter.set_assertion_msg(module_id, case_id, assertion_msg)

--- a/hardpy/pytest_hardpy/pytest_wrapper.py
+++ b/hardpy/pytest_hardpy/pytest_wrapper.py
@@ -45,6 +45,8 @@ class PyTestWrapper:
                     "pytest",
                     "--hardpy-db-url",
                     self.config.database.connection_url(),
+                    "--hardpy-tests-name",
+                    self.config.tests_name,
                     "--sc-address",
                     self.config.stand_cloud.address,
                     "--sc-connection-only"
@@ -62,6 +64,8 @@ class PyTestWrapper:
                     "pytest",
                     "--hardpy-db-url",
                     self.config.database.connection_url(),
+                    "--hardpy-tests-name",
+                    self.config.tests_name,
                     "--sc-address",
                     self.config.stand_cloud.address,
                     "--sc-connection-only"
@@ -111,6 +115,8 @@ class PyTestWrapper:
             "--collect-only",
             "--hardpy-db-url",
             self.config.database.connection_url(),
+            "--hardpy-tests-name",
+            self.config.tests_name,
             "--hardpy-pt",
         ]
 
@@ -149,3 +155,11 @@ class PyTestWrapper:
             bool | None: True if self._proc is not None
         """
         return self._proc and self._proc.poll() is None
+
+    def get_config(self) -> dict:
+        """Get HardPy configuration.
+
+        Returns:
+            dict: HardPy configuration
+        """
+        return ConfigManager().get_config().model_dump()

--- a/hardpy/pytest_hardpy/result/__init__.py
+++ b/hardpy/pytest_hardpy/result/__init__.py
@@ -6,9 +6,13 @@ from hardpy.pytest_hardpy.result.report_loader.stand_cloud_loader import (
     StandCloudLoader,
 )
 from hardpy.pytest_hardpy.result.report_reader.couchdb_reader import CouchdbReader
+from hardpy.pytest_hardpy.result.report_reader.stand_cloud_reader import (
+    StandCloudReader,
+)
 
 __all__ = [
     "CouchdbLoader",
     "CouchdbReader",
     "StandCloudLoader",
+    "StandCloudReader",
 ]

--- a/hardpy/pytest_hardpy/result/couchdb_config.py
+++ b/hardpy/pytest_hardpy/result/couchdb_config.py
@@ -58,17 +58,17 @@ class CouchdbConfig:
 
         try:
             response = requests.get(host_url, timeout=5)
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as exc:
             msg = f"Error CouchDB connecting to {host_url}."
-            raise RuntimeError(msg)  # noqa: B904
+            raise RuntimeError(msg) from exc
 
         # fmt: off
         try:
             couchdb_dict = ast.literal_eval(response._content.decode("utf-8"))  # type: ignore # noqa: SLF001
             couchdb_dict.get("couchdb", False)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:
             msg = f"Address {host_url} does not provide CouchDB attributes."
-            raise RuntimeError(msg)  # noqa: B904
+            raise RuntimeError(msg) from exc
         # fmt: on
 
         credentials = f"{self.user}:{self.password}"
@@ -93,8 +93,6 @@ class CouchdbConfig:
                 if requests.get(request, timeout=5).status_code == success:
                     return "http"
                 raise OSError  # noqa: TRY301
-            except OSError:
+            except OSError as exc:
                 msg = f"Error connecting to couchdb server {self.host}:{self.port}."
-                raise RuntimeError(  # noqa: B904
-                    msg,
-                )
+                raise RuntimeError(msg) from exc

--- a/hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py
+++ b/hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py
@@ -45,7 +45,7 @@ class StandCloudLoader:
         Raises:
             StandCloudError: if report not uploaded to StandCloud
         """
-        api = self._sc_connector.get_api("api/test_run")
+        api = self._sc_connector.get_api("test_run")
 
         try:
             resp = api.post(verify=self._verify_ssl, json=report.model_dump())

--- a/hardpy/pytest_hardpy/result/report_reader/stand_cloud_reader.py
+++ b/hardpy/pytest_hardpy/result/report_reader/stand_cloud_reader.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Everypin
+# GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlencode
+
+from oauthlib.oauth2.rfc6749.errors import OAuth2Error
+from requests.exceptions import RequestException
+
+from hardpy.common.stand_cloud.connector import StandCloudConnector, StandCloudError
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from requests import Response
+    from requests_oauth2client import ApiClient
+
+
+class StandCloudReader:
+    """StandCloud data reader.
+
+    The link to the documentation can be obtained by address:
+    https://service_name/integration/api/v1/docs
+
+    For example:
+    https://demo.standcloud.io/integration/api/v1/docs
+    """
+
+    def __init__(self, sc_connector: StandCloudConnector) -> None:
+        """Create StandCloud reader.
+
+        Args:
+            sc_connector (StandCloudConnector): StandCloud connector
+        """
+        self._verify_ssl = not __debug__
+        self._sc_connector = sc_connector
+
+    def test_run(self, run_id: str) -> Response:
+        """Get run data from '/test_run' endpoint.
+
+        Args:
+            run_id (str): UUIDv4 test run identifier.
+                Example: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+        Returns:
+            Response: test run data.
+        """
+        return self._request(endpoint=f"test_run/{run_id}")
+
+    def tested_dut(self, params: dict[str, Any]) -> Response:
+        """Get tested DUT's data from '/tested_dut' endpoint.
+
+        Args:
+            params (dict[str, Any]): tested DUT filters:
+                Examples: {
+                    "test_stand_name": "Stand 1",
+                    "part_number": "part_number_1",
+                    "firmware_version": "1.2.3",
+                }
+
+        Returns:
+            Response: tested dut data.
+        """
+        return self._request(endpoint="tested_dut", params=params)
+
+    def _request(self, endpoint: str, params: dict[str, Any] | None = None) -> Response:
+        api = self._build_api(endpoint=endpoint, params=params)
+        try:
+            resp = api.get(verify=self._verify_ssl)
+        except RuntimeError as exc:
+            raise StandCloudError(str(exc)) from exc
+        except OAuth2Error as exc:
+            raise StandCloudError(exc.description) from exc
+        except RequestException as exc:
+            return exc.response  # type: ignore
+
+        return resp
+
+    def _build_api(self, endpoint: str, params: dict | None = None) -> ApiClient:
+        if params is None:
+            return self._sc_connector.get_api(f"{endpoint}")
+        encoded_params = urlencode(params)
+        return self._sc_connector.get_api(f"{endpoint}?{encoded_params}")

--- a/hardpy/pytest_hardpy/utils/dialog_box.py
+++ b/hardpy/pytest_hardpy/utils/dialog_box.py
@@ -289,9 +289,9 @@ class ImageComponent:
         try:
             with open(address, "rb") as file:  # noqa: PTH123
                 file_data = file.read()
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
             msg = "The image address is invalid"
-            raise ImageError(msg)  # noqa: B904
+            raise ImageError(msg) from exc
         self.address = address
         self.width = width
         self.border = border

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Operator message: examples/operator_msg.md
       - Skip test: examples/skip_test.md
       - StandCloud: examples/stand_cloud.md
+      - StandCloud read data: examples/stand_cloud_reader.md
   - About:
       - Development: about/development.md
       - Frontend data synchronization: about/fronted_sync.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
     name = "hardpy"
-    version = "0.11.0"
+    version = "0.11.1"
     description = "HardPy library for device testing"
     license = "GPL-3.0-or-later"
     authors = [{ name = "Everypin", email = "info@everypin.io" }]

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -10,6 +10,7 @@ from hardpy.common.config import (
     StandCloudConfig,
 )
 
+tests_no_default_name = "Tests1"
 db_no_default_user = "dev1"
 db_no_default_password = "dev1"
 db_no_default_host = "localhost1"
@@ -31,6 +32,7 @@ def test_config_manager_init(tmp_path: Path):
     tests_dir = tmp_path / "my_tests"
     ConfigManager.init_config(
         tests_dir=str(tests_dir),
+        tests_name=tests_no_default_name,
         database_user=db_no_default_user,
         database_password=db_no_default_password,
         database_host=db_no_default_host,
@@ -42,6 +44,7 @@ def test_config_manager_init(tmp_path: Path):
     config = ConfigManager.get_config()
     assert isinstance(config, HardpyConfig)
     assert config.tests_dir == str(tests_dir)
+    assert config.tests_name == tests_no_default_name
     assert config.database.user == db_no_default_user
     assert config.database.password == db_no_default_password
     assert config.database.host == db_no_default_host
@@ -80,12 +83,14 @@ def test_hardpy_config():
     config = HardpyConfig(
         title="HardPy TOML config",
         tests_dir="tests",
+        tests_name="tests",
         database=DatabaseConfig(),
         frontend=FrontendConfig(),
         stand_cloud=StandCloudConfig(),
     )
     assert config.title == "HardPy TOML config"
     assert config.tests_dir == "tests"
+    assert config.tests_name == "tests"
     assert config.database.user == db_default_user
     assert config.database.password == db_default_password
     assert config.database.host == db_default_host
@@ -101,6 +106,7 @@ def test_config_manager_create_config(tmp_path: Path):
 
     ConfigManager.init_config(
         tests_dir=str(tests_dir),
+        tests_name=str(tests_dir),
         database_user=db_default_user,
         database_password=db_default_password,
         database_host=db_default_host,
@@ -122,6 +128,7 @@ def test_read_config_success(tmp_path: Path):
     test_config_data = {
         "title": "Test HardPy Config",
         "tests_dir": "my_tests",
+        "tests_name": "My tests",
         "database": {
             "user": db_default_user,
             "password": db_default_password,
@@ -142,6 +149,7 @@ def test_read_config_success(tmp_path: Path):
     assert isinstance(config, HardpyConfig)
     assert config.title == test_config_data["title"]
     assert config.tests_dir == test_config_data["tests_dir"]
+    assert config.tests_name == test_config_data["tests_name"]
     assert config.database.user == test_config_data["database"]["user"]
     assert config.database.password == test_config_data["database"]["password"]
     assert config.database.host == test_config_data["database"]["host"]

--- a/tests/test_plugin/test_dependency.py
+++ b/tests/test_plugin/test_dependency.py
@@ -360,6 +360,160 @@ def test_case_dependency_from_big_module(pytester: Pytester, hardpy_opts: list[s
     result.assert_outcomes(passed=2, failed=1, skipped=3)
 
 
+def test__module_stop_time_first_case_skip(pytester: Pytester, hardpy_opts: list[str]):
+    """Check module stop time.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_stop_time = report.modules["test_1"].stop_time
+            module_start_time = report.modules["test_1"].start_time
+
+            assert module_stop_time >= module_start_time
+
+            case_2_stop_time = report.modules["test_1"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_1"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            assert False
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=0, failed=1, skipped=1)
+
+
+def test_first_case_skip_third_case_pass(pytester: Pytester, hardpy_opts: list[str]):
+    """Check module stop time.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_stop_time = report.modules["test_1"].stop_time
+            module_start_time = report.modules["test_1"].start_time
+
+            assert module_stop_time >= module_start_time
+
+            case_2_stop_time = report.modules["test_1"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_1"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+            case_3_stop_time = report.modules["test_1"].cases["test_three"].stop_time
+            case_3_start_time = report.modules["test_1"].cases["test_three"].start_time
+
+            assert case_3_stop_time >= case_3_start_time
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            assert False
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+
+        def test_three():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=1, failed=1, skipped=1)
+
+
+def test_first_case_user_skip(pytester: Pytester, hardpy_opts: list[str]):
+    """Check stop_time in test skipped by user.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_stop_time = report.modules["test_1"].stop_time
+            module_start_time = report.modules["test_1"].start_time
+
+            assert module_stop_time >= module_start_time
+
+            case_1_stop_time = report.modules["test_1"].cases["test_one"].stop_time
+            case_1_start_time = report.modules["test_1"].cases["test_one"].start_time
+
+            assert case_1_stop_time >= case_1_start_time
+
+            case_2_stop_time = report.modules["test_1"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_1"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            pytest.skip()
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=0, failed=0, skipped=2)
+
+
 def test_module_dependency_from_failed_case(pytester: Pytester, hardpy_opts: list[str]):
     pytester.makepyfile(
         test_1="""

--- a/tests/test_plugin/test_dependency.py
+++ b/tests/test_plugin/test_dependency.py
@@ -360,7 +360,7 @@ def test_case_dependency_from_big_module(pytester: Pytester, hardpy_opts: list[s
     result.assert_outcomes(passed=2, failed=1, skipped=3)
 
 
-def test__module_stop_time_first_case_skip(pytester: Pytester, hardpy_opts: list[str]):
+def test_module_stop_time_first_case_skip(pytester: Pytester, hardpy_opts: list[str]):
     """Check module stop time.
 
     PR-129: https://github.com/everypinio/hardpy/pull/129
@@ -448,6 +448,131 @@ def test_first_case_skip_third_case_pass(pytester: Pytester, hardpy_opts: list[s
 
         def test_one():
             assert False
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+
+        def test_three():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=1, failed=1, skipped=1)
+
+
+def test_last_case_skip_from_2_file(pytester: Pytester, hardpy_opts: list[str]):
+    """Check module stop time.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_1_stop_time = report.modules["test_1"].stop_time
+            module_1_start_time = report.modules["test_1"].start_time
+
+            assert module_1_stop_time >= module_1_start_time
+
+            module_2_stop_time = report.modules["test_2"].stop_time
+            module_2_start_time = report.modules["test_2"].start_time
+
+            assert module_2_stop_time >= module_2_start_time
+
+            case_2_stop_time = report.modules["test_2"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_2"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            assert False
+    """,
+    )
+    pytester.makepyfile(
+        test_2="""
+        import pytest
+
+        @pytest.mark.dependency("test_1::test_one")
+        def test_two():
+            assert True
+    """,
+    )
+
+    result = pytester.runpytest(*hardpy_opts)
+    result.assert_outcomes(passed=0, failed=1, skipped=1)
+
+
+def test_penultimate_case_skip_from_second_file(
+    pytester: Pytester,
+    hardpy_opts: list[str],
+):
+    """Check module stop time.
+
+    PR-129: https://github.com/everypinio/hardpy/pull/129
+    """
+    pytester.makeconftest(
+        """
+        import pytest
+        import hardpy
+
+        def finish_executing():
+            report = hardpy.get_current_report()
+
+            module_1_stop_time = report.modules["test_1"].stop_time
+            module_1_start_time = report.modules["test_1"].start_time
+
+            assert module_1_stop_time >= module_1_start_time
+
+            module_2_stop_time = report.modules["test_2"].stop_time
+            module_2_start_time = report.modules["test_2"].start_time
+
+            assert module_2_stop_time >= module_2_start_time
+
+            case_2_stop_time = report.modules["test_2"].cases["test_two"].stop_time
+            case_2_start_time = report.modules["test_2"].cases["test_two"].start_time
+
+            assert case_2_stop_time is None
+            assert case_2_start_time is None
+
+            case_3_stop_time = report.modules["test_2"].cases["test_three"].stop_time
+            case_3_start_time = report.modules["test_2"].cases["test_three"].start_time
+
+            assert case_3_stop_time >= case_3_start_time
+
+        @pytest.fixture(scope="session", autouse=True)
+        def actions_after(post_run_functions: list):
+            post_run_functions.append(finish_executing)
+            yield
+    """,
+    )
+    pytester.makepyfile(
+        test_1="""
+        import pytest
+
+        def test_one():
+            assert False
+    """,
+    )
+    pytester.makepyfile(
+        test_2="""
+        import pytest
 
         @pytest.mark.dependency("test_1::test_one")
         def test_two():


### PR DESCRIPTION
## About

* Change **StandCloud** URL for publish test report to `/test_report`. [[PR-131](https://github.com/everypinio/hardpy/pull/131)]
* Add `StandCloudReader` class for reading data from **StandCloud**. [[PR-131](https://github.com/everypinio/hardpy/pull/131)]
* Fix the behavior with empty module start time with skipped test. [[PR-131](https://github.com/everypinio/hardpy/pull/131)]
* Fix the behavior with empty module stop time with skipped test. [[PR-129](https://github.com/everypinio/hardpy/pull/129)]
* Add Stand info to Operator panel. [[PR-127](https://github.com/everypinio/hardpy/pull/127)]
* Add the `tests_name` field to **hardpy.toml**. The `tests_name` allows to name the test suite in the operator panel. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
* Add CLI commands: `hardpy start`, `hardpy stop` and `hardpy status`. [[PR-126](https://github.com/everypinio/hardpy/pull/126)]
* Change the StandCloud API address to `/hardpy/api`. [[PR-125](https://github.com/everypinio/hardpy/pull/125)]