### PR TITLE
Fix StandCloud login support in version 3.12+

### DIFF
--- a/hardpy/common/stand_cloud/connector.py
+++ b/hardpy/common/stand_cloud/connector.py
@@ -69,7 +69,7 @@ class StandCloudConnector:
         auth_addr = addr + "/auth"
 
         self._url: StandCloudURL = StandCloudURL(
-            api=https_prefix + addr + f"/{api_mode}/api/v{api_version}",
+            api=https_prefix + addr + f"/{api_mode.value}/api/v{api_version}",
             token=https_prefix + auth_addr + "/api/oidc/token",
             par=https_prefix + auth_addr + "/api/oidc/pushed-authorization-request",
             auth=https_prefix + auth_addr + "/api/oidc/authorization",


### PR DESCRIPTION
## About

Fix StandCloud API adress creation in python version 3.12+.