### PR TITLE
Fix StandCloud `test_run` response example

### DIFF
--- a/docs/examples/stand_cloud_reader.md
+++ b/docs/examples/stand_cloud_reader.md
@@ -69,11 +69,7 @@ https://demo.standcloud.io/integration/api/v1/docs
     "calibration_date": "2025-01-15"
   },
   "dut_info": {
-    "serial_number": "SN-98765",
-    "part_number": "PN-54321AB",
-    "info": {
-      "manufacturer": "ABC Corp"
-    }
+    "manufacturer": "ABC Corp"
   }
 }
 ```


### PR DESCRIPTION
## About 

Fix **StandCloud** `test_run` response example. Remove excess fieds from `dut_info`.