### PR TITLE
Update the status of the stopped tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Update the status of the test case and module when the test stops.
+  Only one case and one module receive the "stopped" status, while the rest are marked as "skipped."
+  [[PR-154](https://github.com/everypinio/hardpy/pull/154)]
 * Change **StandCloud** authorization process to OAuth2 Device Flow by
   [RFC8628](https://datatracker.ietf.org/doc/html/rfc8628).
   [[PR-152](https://github.com/everypinio/hardpy/pull/152)]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Add an alert to operator panel when the following are called not from tests:
+  `set_message`, `set_case_artifact`, `set_module_artifact`, `run_dialog_box`,
+  and `get_current_attempt`.
+  [[PR-154](https://github.com/everypinio/hardpy/pull/154)]
 * Update the status of the test case and module when the test stops.
   Only one case and one module receive the "stopped" status, while the rest are marked as "skipped."
   [[PR-154](https://github.com/everypinio/hardpy/pull/154)]

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -167,6 +167,8 @@ When called again, the data will be added to DB.
 Artifacts are saved only in the **runstore** database
 because the state in **statestore** and case artifact must be separated.
 
+The `set_case_artifact` function must be called from a test case.
+
 **Arguments:**
 
 - `data` *(dict)*: data
@@ -185,6 +187,8 @@ When called again, the data will be added to DB.
 
 Artifacts are saved only in the **runstore** database
 because the state in **statestore** and module artifact must be separated.
+
+The `set_module_artifact` function must be called from a test case.
 
 **Arguments:**
 
@@ -222,6 +226,8 @@ Writes a string with a message.
 If a message is sent without a key, the key will be generated
 automatically and the messages will be appended.
 If the message is sent with a known key, it will be updated.
+
+The `set_message` function must be called from a test case.
 
 **Arguments:**
 
@@ -280,6 +286,8 @@ def test_clear_operator_msg():
 
 Displays a dialog box and updates the `dialog_box` field in the **statestore** database.
 
+The `run_dialog_box` function must be called from a test case.
+
 **Arguments:**
 
 - `dialog_box_data` *(DialogBox)*: Data for the dialog box.
@@ -335,6 +343,8 @@ def test_current_report():
 #### get_current_attempt
 
 Returns the num of current attempt.
+
+The `get_current_attempt` function must be called from a test case.
 
 **Returns:**
 

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -338,7 +338,7 @@ Returns the num of current attempt.
 
 **Returns:**
 
-- *(int)*: num of current attempt. If the function is called outside of test, returns -1
+- *(int)*: num of current attempt
 
 **Example:**
 

--- a/docs/documentation/pytest_hardpy.md
+++ b/docs/documentation/pytest_hardpy.md
@@ -338,7 +338,7 @@ Returns the num of current attempt.
 
 **Returns:**
 
-- *(int)*: num of current attempt
+- *(int)*: num of current attempt. If the function is called outside of test, returns -1
 
 **Example:**
 

--- a/hardpy/hardpy_panel/frontend/src/button/StartStop.tsx
+++ b/hardpy/hardpy_panel/frontend/src/button/StartStop.tsx
@@ -6,13 +6,22 @@ import { AnchorButton, AnchorButtonProps } from "@blueprintjs/core";
 
 type Props = { testing_status: string };
 
+type State = {
+  isStopButtonDisabled: boolean;
+};
+
 /**
  * A React component that renders a start/stop button for controlling a testing process.
  * The button's behavior and appearance depend on the testing status.
  */
-export class StartStopButton extends React.Component<Props> {
+export class StartStopButton extends React.Component<Props, State> {
+  private stopButtonTimer: NodeJS.Timeout | null = null;
+
   constructor(props: Props) {
     super(props);
+    this.state = {
+      isStopButtonDisabled: false
+    };
     this.hardpy_start = this.hardpy_start.bind(this);
     this.hardpy_stop = this.hardpy_stop.bind(this);
   }
@@ -49,7 +58,16 @@ export class StartStopButton extends React.Component<Props> {
    * @private
    */
   private hardpy_stop(): void {
+    if (this.state.isStopButtonDisabled) {
+      return;
+    }
     this.hardpy_call("api/stop");
+
+    // Disable the stop button for some time
+    this.setState({ isStopButtonDisabled: true });
+    this.stopButtonTimer = setTimeout(() => {
+      this.setState({ isStopButtonDisabled: false });
+  }, 500);
   }
 
   /**
@@ -85,6 +103,9 @@ export class StartStopButton extends React.Component<Props> {
    */
   componentWillUnmount(): void {
     window.removeEventListener("keydown", this.hardpy_start_with_space);
+    if (this.stopButtonTimer) {
+      clearTimeout(this.stopButtonTimer);
+    }
   }
 
   /**
@@ -111,6 +132,7 @@ export class StartStopButton extends React.Component<Props> {
       rightIcon: "play",
       onClick: this.handleButtonClick,
       id: button_id,
+      disabled: this.state.isStopButtonDisabled,
     };
 
     return <AnchorButton {...(is_testing ? stop_button : start_button)} />;

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -415,13 +415,13 @@ class HardpyPlugin:
                 return TestStatus.FAILED
 
     def _stop_tests(self) -> None:
-        """Update module and case statuses from READY or RUN to STOPPED and SKIPPED."""
+        """Update module and case statuses to stopped and skipped."""
         is_module_stopped = False
         is_case_stopped = False
+        valid_statuses = {TestStatus.PASSED, TestStatus.FAILED, TestStatus.SKIPPED}
         for module_id, module_data in self._results.items():
             module_status = self._reporter.get_module_status(module_id)
-            # skip passed and failed modules
-            if module_status in {TestStatus.PASSED, TestStatus.FAILED}:
+            if module_status in valid_statuses:
                 continue
 
             is_module_stopped = self._stop_module(module_id, is_module_stopped)
@@ -431,8 +431,7 @@ class HardpyPlugin:
                     continue
                 case_id = module_data_key
                 case_status = self._reporter.get_case_status(module_id, case_id)
-                # skip passed and failed cases
-                if case_status in {TestStatus.PASSED, TestStatus.FAILED}:
+                if case_status in valid_statuses:
                     continue
                 is_case_stopped = self._stop_case(module_id, case_id, is_case_stopped)
 

--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -175,6 +175,8 @@ class HardpyPlugin:
         if "--collect-only" in session.config.invocation_params.args:
             return
         status = self._get_run_status(exitstatus)
+        if status == TestStatus.STOPPED:
+            self._stop_tests()
         self._reporter.finish(status)
         self._reporter.update_db_by_doc()
         self._reporter.compact_all()
@@ -408,7 +410,6 @@ class HardpyPlugin:
             case ExitCode.TESTS_FAILED:
                 return TestStatus.FAILED
             case ExitCode.INTERRUPTED:
-                self._stop_tests()
                 return TestStatus.STOPPED
             case _:
                 return TestStatus.FAILED

--- a/hardpy/pytest_hardpy/pytest_call.py
+++ b/hardpy/pytest_hardpy/pytest_call.py
@@ -180,8 +180,12 @@ def set_message(msg: str, msg_key: str | None = None) -> None:
         msg_key (Optional[str]): Message ID.
                                      If not specified, a random ID will be generated.
     """
-    current_test = _get_current_test()
     reporter = RunnerReporter()
+    try:
+        current_test = _get_current_test()
+    except RuntimeError:
+        reporter.set_alert(f"Message can't be set outside of test. Message: {msg}")
+        return
 
     if msg_key is None:
         msg_key = str(uuid4())
@@ -213,8 +217,12 @@ def set_case_artifact(data: dict) -> None:
     Args:
         data (dict): data
     """
-    current_test = _get_current_test()
     reporter = RunnerReporter()
+    try:
+        current_test = _get_current_test()
+    except RuntimeError:
+        reporter.set_alert("Case artifact can't be set outside of test.")
+        return
     for stand_key, stand_value in data.items():
         key = reporter.generate_key(
             DF.MODULES,
@@ -237,8 +245,12 @@ def set_module_artifact(data: dict) -> None:
     Args:
         data (dict): data
     """
-    current_test = _get_current_test()
     reporter = RunnerReporter()
+    try:
+        current_test = _get_current_test()
+    except RuntimeError:
+        reporter.set_alert("Module artifact can't be set outside of test.")
+        return
     for artifact_key, artifact_value in data.items():
         key = reporter.generate_key(
             DF.MODULES,
@@ -323,8 +335,12 @@ def run_dialog_box(dialog_box_data: DialogBox) -> Any:  # noqa: ANN401
     if not dialog_box_data.dialog_text:
         msg = "The 'dialog_text' argument cannot be empty."
         raise ValueError(msg)
-    current_test = _get_current_test()
     reporter = RunnerReporter()
+    try:
+        current_test = _get_current_test()
+    except RuntimeError:
+        reporter.set_alert("Dialog box can't be called outside of test")
+        return None
     key = reporter.generate_key(
         DF.MODULES,
         current_test.module_id,
@@ -409,10 +425,14 @@ def get_current_attempt() -> int:
     """Get current attempt.
 
     Returns:
-        int: current attempt
+        int: current attempt. If the function is called outside of test, returns -1
     """
     reporter = RunnerReporter()
-    module_id, case_id = _get_current_test().module_id, _get_current_test().case_id
+    try:
+        module_id, case_id = _get_current_test().module_id, _get_current_test().case_id
+    except RuntimeError:
+        reporter.set_alert("Current attempt can't be called outside of test.")
+        return -1
     return reporter.get_current_attempt(module_id, case_id)
 
 

--- a/hardpy/pytest_hardpy/reporter/base.py
+++ b/hardpy/pytest_hardpy/reporter/base.py
@@ -53,6 +53,14 @@ class BaseReporter:
         self._runstore.update_doc_value(key, value)
         self._statestore.update_doc_value(key, value)
 
+    def set_alert(self, alert: str) -> None:
+        """Set alert message.
+
+        Args:
+            alert (str): alert message
+        """
+        self.set_doc_value(DF.ALERT, alert, statestore_only=True)
+
     def update_db_by_doc(self) -> None:
         """Update database by current document."""
         self._statestore.update_db()

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -129,6 +129,19 @@ class HookReporter(BaseReporter):
         key = self.generate_key(DF.MODULES, module_id, DF.CASES, case_id, DF.STATUS)
         self.set_doc_value(key, status)
 
+    def get_case_status(self, module_id: str, case_id: str) -> str:
+        """Set test case status.
+
+        Args:
+            module_id (str): module id
+            case_id (str): case id
+
+        Returns:
+            str: test case status
+        """
+        key = self.generate_key(DF.MODULES, module_id, DF.CASES, case_id, DF.STATUS)
+        return self._statestore.get_field(key)
+
     def set_case_start_time(self, module_id: str, case_id: str) -> None:
         """Set test case start_time.
 
@@ -158,6 +171,18 @@ class HookReporter(BaseReporter):
         """
         key = self.generate_key(DF.MODULES, module_id, DF.STATUS)
         self.set_doc_value(key, status)
+
+    def get_module_status(self, module_id: str) -> str:
+        """Get test module status.
+
+        Args:
+            module_id (str): module id
+
+        Returns:
+            str: test module status
+        """
+        key = self.generate_key(DF.MODULES, module_id, DF.STATUS)
+        return self._statestore.get_field(key)
 
     def set_module_start_time(self, module_id: str) -> None:
         """Set test module status.
@@ -193,14 +218,6 @@ class HookReporter(BaseReporter):
             DF.ATTEMPT,
         )
         self.set_doc_value(key, attempt, statestore_only=True)
-
-    def set_alert(self, alert: str) -> None:
-        """Set alert message.
-
-        Args:
-            alert (str): alert message
-        """
-        self.set_doc_value(DF.ALERT, alert, statestore_only=True)
 
     def get_module_start_time(self, module_id: str) -> int:
         """Get module start time.


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include a detailed PR description with the objectives of the change.
- [ ] Include documentation when adding new features or updating existing.
- [ ] Include new tests or update existing tests if applicable.
- [ ] Update the changelog.md file. 
-->

## About

* Update the status of the test case and module when the test stops. Only one case and one module receive the "stopped" status, while the rest are marked as "skipped."
* Add an alert to operator panel when the following are called not from tests: `set_message`, `set_case_artifact`, `set_module_artifact`, `run_dialog_box`, and `get_current_attempt`.
* Add a pause to avoid double clicking the stop button. 
