### PR TITLE
Update package to 0.13.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+## HardPy 0.13.0
+
 * Add an alert to operator panel when the following are called not from tests:
   `set_message`, `set_case_artifact`, `set_module_artifact`, `run_dialog_box`,
   and `get_current_attempt`.

--- a/hardpy/common/stand_cloud/connector.py
+++ b/hardpy/common/stand_cloud/connector.py
@@ -211,12 +211,15 @@ class StandCloudConnector:
                 f"Login to {self._addr.domain} first"
             )
             raise StandCloudError(msg)
-        auth = OAuth2(
-            sc_addr=self._addr,
-            client_id=self._client_id,
-            token=self._token,
-            token_manager=self._token_manager,
-            verify_ssl=self._verify_ssl,
-        )
+        try:
+            auth = OAuth2(
+                sc_addr=self._addr,
+                client_id=self._client_id,
+                token=self._token,
+                token_manager=self._token_manager,
+                verify_ssl=self._verify_ssl,
+            )
+        except OAuth2Error as exc:
+            raise StandCloudError(exc.description) from exc
         session = auth.session
         return ApiClient(f"{self._addr.api}/{endpoint}", session=session, timeout=10)

--- a/hardpy/common/stand_cloud/connector.py
+++ b/hardpy/common/stand_cloud/connector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
 from logging import getLogger
 from time import sleep
 from typing import TYPE_CHECKING
@@ -123,6 +124,8 @@ class StandCloudConnector:
             verify=self._verify_ssl,
             timeout=10,
         )
+        if req.status_code != HTTPStatus.OK:
+            raise StandCloudError(req.text)
         return json.loads(req.content)
 
     def get_api(self, endpoint: str) -> ApiClient:

--- a/hardpy/common/stand_cloud/registration.py
+++ b/hardpy/common/stand_cloud/registration.py
@@ -12,6 +12,7 @@ from qrcode import QRCode
 from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
 from requests_oauth2client.tokens import ExpiredAccessToken
 
+from hardpy.common.stand_cloud.exception import StandCloudError
 from hardpy.common.stand_cloud.token_manager import TokenManager
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ def login(sc_connector: StandCloudConnector) -> None:
     if token is None or sc_connector.is_refresh_token_valid() is False:
         try:
             response = sc_connector.get_verification_url()
-        except RequestConnectionError as e:
+        except (RequestConnectionError, StandCloudError) as e:
             print(f"Connection error to StandCloud: {sc_connector.addr}. \nError: {e}")
             return
         url = response["verification_uri_complete"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
     name = "hardpy"
-    version = "0.12.1"
+    version = "0.13.0"
     description = "HardPy library for device testing"
     license = "GPL-3.0-or-later"
     authors = [{ name = "Everypin", email = "info@everypin.io" }]


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include a detailed PR description with the objectives of the change.
- [ ] Include documentation when adding new features or updating existing.
- [ ] Include new tests or update existing tests if applicable.
- [ ] Update the changelog.md file. 
-->

## About

Update package to 0.13.0

## StandCloud authorization
Authorization has been replaced by the OAuth 2.0 device flow. **There is no backward compatibility with the previous authorization version.**

* The OAuth2 callback page has been removed from the **HardPy** side during authorization.
* Added QR code output for authorization from third-party devices if the user cannot access a browser on a device running HardPy.
* Added the ability to log in to multiple **StandCloud** instances.
* Logout of **StandCloud** now requires the address of a **StandCloud** instance. For example:
  ```bash
  hardpy sc-logout demo.standcloud.io
  ```
* Added examples of working with authorization for third-party applications.
* `ruff` in CI is configured for the **HardPy** folder only.

## Test statuses
* Update the status of the test case and module when the test stops. Only one case and one module receive the "stopped" status, while the rest are marked as "skipped."
* Add an alert to operator panel when the following are called not from tests: `set_message`, `set_case_artifact`, `set_module_artifact`, `run_dialog_box`, and `get_current_attempt`.
* Add a pause to avoid double clicking the stop button. 

