### PR TITLE
Timeout to the load function of the StandCloudLoader class

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Add a timeout to the `load` function of the `StandCloudLoader` class.
+  [[PR-166](https://github.com/everypinio/hardpy/pull/166)]
 * Fix logic for processing spacebar pressing.
   [[PR-164](https://github.com/everypinio/hardpy/pull/164)]
 * Fix the display of the module duration after the operator panel has been restarted.

--- a/hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py
+++ b/hardpy/pytest_hardpy/result/report_loader/stand_cloud_loader.py
@@ -32,11 +32,13 @@ class StandCloudLoader:
         sc_addr = address if address else connection_data.sc_address
         self._sc_connector = StandCloudConnector(sc_addr)
 
-    def load(self, report: ResultRunStore) -> Response:
+    def load(self, report: ResultRunStore, timeout: int = 20) -> Response:
         """Load report to the StandCloud.
 
         Args:
             report (ResultRunStore): report
+            timeout (int, optional): post timeout in seconds. Defaults to 20.
+                                    High timeout value on poor network connections.
 
         Returns:
             Response: StandCloud load response, must be 201
@@ -47,7 +49,11 @@ class StandCloudLoader:
         api = self._sc_connector.get_api("test_report")
 
         try:
-            resp = api.post(verify=self._verify_ssl, json=report.model_dump())
+            resp = api.post(
+                verify=self._verify_ssl,
+                json=report.model_dump(),
+                timeout=timeout,
+            )
         except RuntimeError as exc:
             raise StandCloudError(str(exc)) from exc
         except OAuth2Error as exc:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include a detailed PR description with the objectives of the change.
- [ ] Include documentation when adding new features or updating existing.
- [ ] Include new tests or update existing tests if applicable.
- [ ] Update the changelog.md file. 
-->

## About

* Add a timeout to the `load` function of the `StandCloudLoader` class.
* The high default timeout value (20 seconds) is useful for poor network connections at the factory.


