### PR TITLE
Remove tests_dir

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+* Remove `tests_dir` variable from **hardpy.toml**. 
+  [[PR-182](https://github.com/everypinio/hardpy/pull/182)]
 * Add check for message presence in set_operator_message.
   [[PR-180](https://github.com/everypinio/hardpy/pull/180)]
 * Add the `ErrorCode` class.

--- a/docs/documentation/hardpy_config.md
+++ b/docs/documentation/hardpy_config.md
@@ -10,7 +10,6 @@ The user can change the fields at creation by using [hardpy init](./cli.md#hardp
 
 ```toml
 title = "HardPy TOML config"
-tests_dir = "tests"
 
 [database]
 user = "dev"
@@ -27,7 +26,6 @@ port = 8000
 
 ```toml
 title = "HardPy TOML config"
-tests_dir = "tests"
 tests_name = "My tests"
 
 [database]
@@ -57,15 +55,9 @@ Common settings.
 Configuration file header.
 The value is always `HardPy TOML config`.
 
-#### tests_dir
-
-Tests directory. The default is `tests`.
-The user can change this value with the `hardpy init` argument.
-
 #### tests_name
 
-Tests name. The default is [tests_dir](#tests_dir).
-The user can change this value with the `hardpy init --tests-name` argument.
+Tests name. The user can change this value with the `hardpy init --tests-name` argument.
 
 ### database
 

--- a/examples/attempts/hardpy.toml
+++ b/examples/attempts/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "minute_parity"
+tests_name = "Attempts"
 
 [database]
 user = "dev"

--- a/examples/couchdb_load/hardpy.toml
+++ b/examples/couchdb_load/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "couchdb_load"
+tests_name = "CouchDB Load"
 
 [database]
 user = "dev"

--- a/examples/dialog_box/hardpy.toml
+++ b/examples/dialog_box/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "dialog_box"
+tests_name = "Dialog Box"
 
 [database]
 user = "dev"

--- a/examples/hello_hardpy/hardpy.toml
+++ b/examples/hello_hardpy/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "hello_hardpy"
+tests_name = "Hello HardPy"
 
 [database]
 user = "dev"

--- a/examples/measurement/hardpy.toml
+++ b/examples/measurement/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "measurement"
+tests_name = "Measurement"
 
 [database]
 user = "dev"

--- a/examples/minute_parity/hardpy.toml
+++ b/examples/minute_parity/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "minute_parity"
+tests_name = "Minute Parity"
 
 [database]
 user = "dev"

--- a/examples/operator_msg/hardpy.toml
+++ b/examples/operator_msg/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "operator_msg"
+tests_name = "Operator Message"
 
 [database]
 user = "dev"

--- a/examples/stand_cloud/hardpy.toml
+++ b/examples/stand_cloud/hardpy.toml
@@ -1,5 +1,5 @@
 title = "HardPy TOML config"
-tests_dir = "stand_cloud"
+tests_name = "StandCloud"
 
 [database]
 user = "dev"

--- a/hardpy/cli/cli.py
+++ b/hardpy/cli/cli.py
@@ -91,11 +91,9 @@ def init(  # noqa: PLR0913
         sc_address (str): StandCloud address
         sc_connection_only (bool): Flag to check StandCloud service availability
     """
-    _tests_dir = tests_dir if tests_dir else default_config.tests_dir
-    _tests_name = tests_name if tests_name else default_config.tests_name
+    dir_path = Path(Path.cwd() / tests_dir if tests_dir else "tests")
     ConfigManager().init_config(
-        tests_dir=str(_tests_dir),
-        tests_name=_tests_name,
+        tests_name=tests_name if tests_name else dir_path.name,
         database_user=database_user,
         database_password=database_password,
         database_host=database_host,
@@ -107,7 +105,6 @@ def init(  # noqa: PLR0913
         sc_connection_only=sc_connection_only,
     )
     # create tests directory
-    dir_path = Path(Path.cwd() / _tests_dir)
     Path.mkdir(dir_path, exist_ok=True, parents=True)
 
     if create_database:
@@ -116,11 +113,8 @@ def init(  # noqa: PLR0913
 
     # create hardpy.toml
     ConfigManager().create_config(dir_path)
-    config = ConfigManager().read_config(dir_path)
-    if not config:
-        print(f"hardpy.toml config by path {dir_path} not detected.")
-        sys.exit()
 
+    config = _get_config(dir_path)
     template = TemplateGenerator(config)
 
     files = {}
@@ -146,12 +140,7 @@ def run(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
     Args:
         tests_dir (Optional[str]): Test directory. Current directory by default
     """
-    dir_path = Path.cwd() / tests_dir if tests_dir else Path.cwd()
-    config = ConfigManager().read_config(dir_path)
-
-    if not config:
-        print(f"Config at path {dir_path} not found.")
-        sys.exit()
+    config = _get_config(tests_dir)
 
     print("\nLaunch the HardPy operator panel...")
 
@@ -191,9 +180,7 @@ def start(
     context_args = getattr(ctx, "hardpy_args", [])
     all_args = arg + context_args
 
-    config = _get_config(tests_dir)
-    _check_config(config)
-
+    config = _get_config(tests_dir, validate=True)
     query_args = "&".join([f"args={urllib.parse.quote(a)}" for a in all_args])
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/start?{query_args}"
     _request_hardpy(url)
@@ -206,9 +193,7 @@ def stop(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None:
     Args:
         tests_dir (Optional[str]): Test directory. Current directory by default
     """
-    config = _get_config(tests_dir)
-    _check_config(config)
-
+    config = _get_config(tests_dir, validate=True)
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/stop"
     _request_hardpy(url)
 
@@ -220,9 +205,7 @@ def status(tests_dir: Annotated[Optional[str], typer.Argument()] = None) -> None
     Args:
         tests_dir (Optional[str]): Test directory. Current directory by default
     """
-    config = _get_config(tests_dir)
-    _check_config(config)
-
+    config = _get_config(tests_dir, validate=True)
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/status"
     _request_hardpy(url)
 
@@ -275,7 +258,7 @@ def sc_logout(address: Annotated[str, typer.Argument()]) -> None:
         print(f"HardPy logout failed from {address}")
 
 
-def _get_config(tests_dir: str | None = None) -> HardpyConfig:
+def _get_config(tests_dir: str | None = None, validate: bool = False) -> HardpyConfig:
     dir_path = Path.cwd() / tests_dir if tests_dir else Path.cwd()
     config = ConfigManager().read_config(dir_path)
 
@@ -283,12 +266,15 @@ def _get_config(tests_dir: str | None = None) -> HardpyConfig:
         print(f"Config at path {dir_path} not found.")
         sys.exit()
 
+    if validate:
+        _validate_config(config, dir_path)
+
     return config
 
 
-def _check_config(config: HardpyConfig) -> None:
+def _validate_config(config: HardpyConfig, tests_dir: str) -> None:
     url = f"http://{config.frontend.host}:{config.frontend.port}/api/hardpy_config"
-    error_msg = f"HardPy in directory {config.tests_dir} does not run."
+    error_msg = f"HardPy in directory {tests_dir} does not run."
     try:
         response = requests.get(url, timeout=2)
     except Exception:

--- a/hardpy/common/config.py
+++ b/hardpy/common/config.py
@@ -58,7 +58,6 @@ class HardpyConfig(BaseModel, extra="allow"):
     model_config = ConfigDict(extra="forbid")
 
     title: str = "HardPy TOML config"
-    tests_dir: str = "tests"
     tests_name: str = ""
     database: DatabaseConfig = DatabaseConfig()
     frontend: FrontendConfig = FrontendConfig()
@@ -74,7 +73,6 @@ class ConfigManager:
     @classmethod
     def init_config(  # noqa: PLR0913
         cls,
-        tests_dir: str,
         tests_name: str,
         database_user: str,
         database_password: str,
@@ -89,7 +87,6 @@ class ConfigManager:
         """Initialize HardPy configuration.
 
         Args:
-            tests_dir (str): Tests directory.
             tests_name (str): Tests suite name.
             database_user (str): Database user name.
             database_password (str): Database password.
@@ -101,7 +98,6 @@ class ConfigManager:
             sc_address (str): StandCloud address.
             sc_connection_only (bool): StandCloud check availability.
         """
-        cls.obj.tests_dir = str(tests_dir)
         cls.obj.tests_name = tests_name
         cls.obj.database.user = database_user
         cls.obj.database.password = database_password

--- a/tests/test_cli/test_cmd/conftest.py
+++ b/tests/test_cli/test_cmd/conftest.py
@@ -92,6 +92,10 @@ class HardPyServer:  # noqa: D101
         )
 
 
+def pytest_configure(config) -> None:
+    config.addinivalue_line("markers", "manual")
+
+
 @pytest.fixture
 def project_dir(tmp_path: Path) -> Path:
     """Create a test project with necessary test files."""

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -29,10 +29,8 @@ frontend_default_language = "en"
 stand_cloud_default_addr = ""
 
 
-def test_config_manager_init(tmp_path: Path):
-    tests_dir = tmp_path / "my_tests"
+def test_config_manager_init():
     ConfigManager.init_config(
-        tests_dir=str(tests_dir),
         tests_name=tests_no_default_name,
         database_user=db_no_default_user,
         database_password=db_no_default_password,
@@ -45,7 +43,6 @@ def test_config_manager_init(tmp_path: Path):
     )
     config = ConfigManager.get_config()
     assert isinstance(config, HardpyConfig)
-    assert config.tests_dir == str(tests_dir)
     assert config.tests_name == tests_no_default_name
     assert config.database.user == db_no_default_user
     assert config.database.password == db_no_default_password
@@ -86,14 +83,12 @@ def test_stand_cloud_config():
 def test_hardpy_config():
     config = HardpyConfig(
         title="HardPy TOML config",
-        tests_dir="tests",
         tests_name="tests",
         database=DatabaseConfig(),
         frontend=FrontendConfig(),
         stand_cloud=StandCloudConfig(),
     )
     assert config.title == "HardPy TOML config"
-    assert config.tests_dir == "tests"
     assert config.tests_name == "tests"
     assert config.database.user == db_default_user
     assert config.database.password == db_default_password
@@ -110,7 +105,6 @@ def test_config_manager_create_config(tmp_path: Path):
     Path.mkdir(tests_dir, exist_ok=True, parents=True)
 
     ConfigManager.init_config(
-        tests_dir=str(tests_dir),
         tests_name=str(tests_dir),
         database_user=db_default_user,
         database_password=db_default_password,
@@ -133,7 +127,6 @@ def test_config_manager_create_config(tmp_path: Path):
 def test_read_config_success(tmp_path: Path):
     test_config_data = {
         "title": "Test HardPy Config",
-        "tests_dir": "my_tests",
         "tests_name": "My tests",
         "database": {
             "user": db_default_user,
@@ -158,7 +151,6 @@ def test_read_config_success(tmp_path: Path):
     config = ConfigManager.read_config(tests_dir)
     assert isinstance(config, HardpyConfig)
     assert config.title == test_config_data["title"]
-    assert config.tests_dir == test_config_data["tests_dir"]
     assert config.tests_name == test_config_data["tests_name"]
     assert config.database.user == test_config_data["database"]["user"]
     assert config.database.password == test_config_data["database"]["password"]

--- a/tests/test_plugin/hardpy.toml
+++ b/tests/test_plugin/hardpy.toml
@@ -1,5 +1,4 @@
 title = "HardPy TOML config"
-tests_dir = "tests"
 
 [database]
 user = "dev"

--- a/tests/test_plugin/test_func.py
+++ b/tests/test_plugin/test_func.py
@@ -751,28 +751,6 @@ def test_empty_case_message(pytester: Pytester, hardpy_opts: list[str]):
     result.assert_outcomes(passed=1)
 
 
-def test_incorrect_configdata(pytester: Pytester, hardpy_opts: list[str]):
-    pytester.makepyfile(
-        f"""
-        {func_test_header}
-        def test_incorrect_configdata():
-            config = ConfigData(
-                db_host="test-db",
-                db_user="test-user",
-                db_pswd="test-password",
-                db_port=1234,
-                web_host="test-host",
-                web_port=5678,
-                tests_dir="/path/to/tests",
-            )
-            report = hardpy.get_current_report()
-            assert report
-    """,
-    )
-    result = pytester.runpytest(*hardpy_opts)
-    result.assert_outcomes(failed=1)
-
-
 def test_incorrect_couchdbconfig_data(pytester: Pytester, hardpy_opts: list[str]):
     pytester.makepyfile(
         f"""


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include a detailed PR description with the objectives of the change.
- [ ] Include documentation when adding new features or updating existing.
- [ ] Include new tests or update existing tests if applicable.
- [ ] Update the changelog.md file. 
-->

## About
### 1. tests_dir

The `tests_dir` variable was removed from **hardpy.toml** because it is obsolete and unused.

ISSUE: https://github.com/everypinio/hardpy/issues/155

### 2. ConfigData test

The `ConfigData` test was removed. The `ConfigData` class does not exist.

### 3. manual marker

Added a manual marker to the **pytest** configuration in `test_cmd`.
