### PR TITLE
Fix bug in test report save into Couchdb 

### DIFF
--- a/hardpy/pytest_hardpy/plugin.py
+++ b/hardpy/pytest_hardpy/plugin.py
@@ -496,7 +496,7 @@ class HardpyPlugin:
             module_start_time = self._reporter.get_module_start_time(module_id)
             module_stop_time = self._reporter.get_module_stop_time(module_id)
             if module_start_time and not module_stop_time:
-                self._reporter.set_module_stop_time(module_start_time)
+                self._reporter.set_module_stop_time(module_id)
             for module_data_key in module_data:
                 # skip module status
                 if module_data_key == "module_status":
@@ -505,7 +505,7 @@ class HardpyPlugin:
                 case_start_time = self._reporter.get_case_start_time(module_id, case_id)
                 case_stop_time = self._reporter.get_case_stop_time(module_id, case_id)
                 if case_start_time and not case_stop_time:
-                    self._reporter.set_case_stop_time(case_start_time)
+                    self._reporter.set_case_stop_time(module_id, case_id)
 
     def _stop_tests(self) -> None:
         """Update module and case statuses to stopped and skipped."""


### PR DESCRIPTION
Fixed a bug in `HardpyPlugin._validate_stop_time()` where incorrect arguments were passed to reporter methods, causing a TypeError when tests fail.

## Bug Details
  Error:
` TypeError: sequence item 1: expected str instance, int found
`
## Root Cause:
  The `_validate_stop_time()` method was passing timestamp values instead of string IDs.

  This caused reporter.base.generate_key() to fail when trying to join arguments with` ".".join(args)` because it expected all strings but received integers (timestamps).

## Impact

  - Tests that fail or raise exceptions cannot save their results to CouchDB
  - The entire pytest session crashes with INTERNALERROR
  - Test reports are lost, making it impossible to debug test failures
  - Affects any test run where tests fail or are skipped


