### PR TITLE
Add test history view to operator panel

### DIFF
--- a/docs/about/development.md
+++ b/docs/about/development.md
@@ -272,6 +272,21 @@ To add or modify translations for the HardPy operator panel:
       "finishTime": "Finish time",
       "alert": "Alert"
     },
+    "history": {
+      "title": "Test history",
+      "detailTitle": "Test run details",
+      "columns": {
+        "runName": "Run name",
+        "startTime": "Start time",
+        "result": "Result",
+        "serialNumber": "Serial number",
+        "details": "Details"
+      },
+      "viewDetails": "View details",
+      "selected": "Selected",
+      "unknownRun": "Unnamed run",
+      "showMore": "Show more"
+    },
     "testSuite": {
       "nameColumn": "Name",
       "dataColumn": "Data",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 Versions follow [Semantic Versioning](https://semver.org/): `<major>.<minor>.<patch>`.
 
+## 0.24.0
+
+* Add test history view to the operator panel.
+  Operators can browse previous test run results, including status, start time,
+  serial number, and per-test details. The feature is enabled by default and can
+  be disabled via `test_history = false` in `[frontend]` of `hardpy.toml`.
+  Both CouchDB and JSON storage backends are supported.
+
 ## 0.23.1
 
 * Update the **StandCloud** default address.

--- a/docs/documentation/hardpy_config.md
+++ b/docs/documentation/hardpy_config.md
@@ -44,6 +44,7 @@ full_size_button = false
 sound_on = false
 measurement_display = true
 manual_collect = false
+test_history = true
 
 [frontend.modal_result]
 enable = false
@@ -170,7 +171,13 @@ and only the selected tests will be executed when starting the test run.
 When set to `false`, all discovered tests will run automatically as before.
 Default is `false`.
 
-#### modal_result
+#### test_history
+
+Enable or disable the test history view in the operator panel.
+When set to `true`, the operator can view the history of previous test runs.
+Default is `true`.
+
+### modal_result
 
 Modal result windows settings for test completion display.
 

--- a/docs/documentation/hardpy_config.md
+++ b/docs/documentation/hardpy_config.md
@@ -177,7 +177,7 @@ Enable or disable the test history view in the operator panel.
 When set to `true`, the operator can view the history of previous test runs.
 Default is `true`.
 
-### modal_result
+#### modal_result
 
 Modal result windows settings for test completion display.
 

--- a/docs/documentation/hardpy_panel.md
+++ b/docs/documentation/hardpy_panel.md
@@ -474,3 +474,21 @@ auto_dismiss_timeout = 15
     <h1 align="center">
         <img src="https://raw.githubusercontent.com/everypinio/hardpy/main/docs/img/modal_result_stop.png" alt="STOP modal result" style="width:400px;">
     </h1>
+
+### Test history
+
+The operator panel provides a test history view that allows operators to browse results of previous test runs.
+
+**Features**:
+
+- **History List**: View a chronological list of past test executions.
+- **Detailed Results**: Click on a history entry to see the specific test results, including status and measurements for each test case.
+
+**Configuration**:
+
+The test history feature is enabled by default. You can disable it in your `hardpy.toml`:
+
+```toml
+[frontend]
+test_history = false
+```

--- a/hardpy/common/config.py
+++ b/hardpy/common/config.py
@@ -69,6 +69,7 @@ class FrontendConfig(BaseModel):
     sound_on: bool = False
     manual_collect: bool = False
     measurement_display: bool = True
+    test_history: bool = True
     modal_result: ModalResultConfig = Field(default_factory=lambda: ModalResultConfig())
 
 

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -372,6 +372,15 @@ def get_storage_type() -> dict:
     return {"storage_type": config_manager.config.database.storage_type}
 
 
+def _read_json_history_file(json_file: Path) -> dict | None:
+    try:
+        with json_file.open("r") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(f"Error reading {json_file}: {exc}")
+        return None
+
+
 @app.get("/api/json_data")
 def get_json_data() -> dict:
     """Get test run data from JSON storage.
@@ -402,19 +411,16 @@ def get_json_data() -> dict:
 
         rows = []
         for json_file in storage_dir.glob("*.json"):
-            try:
-                with json_file.open("r") as f:
-                    data = json.load(f)
-                doc_id = data.get("_id", json_file.stem)
-                rows.append({
-                    "id": doc_id,
-                    "key": doc_id,
-                    "value": {"rev": data.get("_rev", "1-0")},
-                    "doc": data,
-                })
-            except Exception as exc:
-                logger.warning(f"Error reading {json_file}: {exc}")
+            data = _read_json_history_file(json_file)
+            if data is None:
                 continue
+            doc_id = data.get("_id", json_file.stem)
+            rows.append({
+                "id": doc_id,
+                "key": doc_id,
+                "value": {"rev": data.get("_rev", "1-0")},
+                "doc": data,
+            })
 
         return {"rows": rows, "total_rows": len(rows)}
     except Exception as exc:

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -396,27 +396,27 @@ def get_json_data() -> dict:
                 / "storage"
                 / "statestore",
             )
-        _doc_id = config_manager.config.database.doc_id
-        statestore_file = storage_dir / f"{_doc_id}.json"
 
-        if not statestore_file.exists():
+        if not storage_dir.exists():
             return {"rows": [], "total_rows": 0}
 
-        with statestore_file.open("r") as f:
-            data = json.load(f)
-
-        # Format data to match CouchDB's _all_docs format
-        return {
-            "rows": [
-                {
-                    "id": data.get("_id", ""),
-                    "key": data.get("_id", ""),
+        rows = []
+        for json_file in storage_dir.glob("*.json"):
+            try:
+                with json_file.open("r") as f:
+                    data = json.load(f)
+                doc_id = data.get("_id", json_file.stem)
+                rows.append({
+                    "id": doc_id,
+                    "key": doc_id,
                     "value": {"rev": data.get("_rev", "1-0")},
                     "doc": data,
-                },
-            ],
-            "total_rows": 1,
-        }
+                })
+            except Exception as exc:
+                logger.warning(f"Error reading {json_file}: {exc}")
+                continue
+
+        return {"rows": rows, "total_rows": len(rows)}
     except Exception as exc:
         logger.exception("Error reading JSON storage")
         return {"error": str(exc), "rows": [], "total_rows": 0}

--- a/hardpy/hardpy_panel/api.py
+++ b/hardpy/hardpy_panel/api.py
@@ -435,7 +435,7 @@ def get_json_data() -> dict:
         logger.exception("Error reading JSON storage")
         return {"error": str(exc), "rows": [], "total_rows": 0}
 
-  def _read_json_history_file(json_file: Path) -> dict | None:
+def _read_json_history_file(json_file: Path) -> dict | None:
     try:
         with json_file.open("r") as f:
             return json.load(f)

--- a/hardpy/hardpy_panel/frontend/public/locales/cs/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/cs/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "Čas dokončení",
     "alert": "Upozornění"
   },
+  "history": {
+    "title": "Historie testů",
+    "detailTitle": "Detail spuštění testu",
+    "columns": {
+      "runName": "Název spuštění",
+      "startTime": "Čas spuštění",
+      "result": "Výsledek",
+      "serialNumber": "Sériové číslo",
+      "details": "Detail"
+    },
+    "viewDetails": "Zobrazit detail",
+    "selected": "Vybráno",
+    "unknownRun": "Nepojmenované spuštění",
+    "showMore": "Zobrazit více"
+  },
   "testSuite": {
     "nameColumn": "Název",
     "dataColumn": "Údaje",

--- a/hardpy/hardpy_panel/frontend/public/locales/de/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/de/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "Endzeit",
     "alert": "Warnung"
   },
+  "history": {
+    "title": "Testverlauf",
+    "detailTitle": "Testlauf-Details",
+    "columns": {
+      "runName": "Laufname",
+      "startTime": "Startzeit",
+      "result": "Ergebnis",
+      "serialNumber": "Seriennummer",
+      "details": "Details"
+    },
+    "viewDetails": "Details anzeigen",
+    "selected": "Ausgewählt",
+    "unknownRun": "Unbenannter Lauf",
+    "showMore": "Mehr anzeigen"
+  },
   "testSuite": {
     "nameColumn": "Name",
     "dataColumn": "Daten",

--- a/hardpy/hardpy_panel/frontend/public/locales/en/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/en/translation.json
@@ -69,6 +69,20 @@
     "finishTime": "Finish time",
     "alert": "Alert"
   },
+  "history": {
+    "title": "Test history",
+    "detailTitle": "Test run details",
+    "columns": {
+      "runName": "Run name",
+      "startTime": "Start time",
+      "result": "Result",
+      "serialNumber": "Serial number",
+      "details": "Details"
+    },
+    "viewDetails": "View details",
+    "selected": "Selected",
+    "unknownRun": "Unnamed run"
+  },
   "testSuite": {
     "nameColumn": "Name",
     "dataColumn": "Data",

--- a/hardpy/hardpy_panel/frontend/public/locales/en/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/en/translation.json
@@ -81,7 +81,8 @@
     },
     "viewDetails": "View details",
     "selected": "Selected",
-    "unknownRun": "Unnamed run"
+    "unknownRun": "Unnamed run",
+    "showMore": "Show more"
   },
   "testSuite": {
     "nameColumn": "Name",

--- a/hardpy/hardpy_panel/frontend/public/locales/es/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/es/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "Hora de finalización",
     "alert": "Alerta"
   },
+  "history": {
+    "title": "Historial de pruebas",
+    "detailTitle": "Detalles de la ejecución",
+    "columns": {
+      "runName": "Nombre de ejecución",
+      "startTime": "Hora de inicio",
+      "result": "Resultado",
+      "serialNumber": "Número de serie",
+      "details": "Detalles"
+    },
+    "viewDetails": "Ver detalles",
+    "selected": "Seleccionado",
+    "unknownRun": "Ejecución sin nombre",
+    "showMore": "Mostrar más"
+  },
   "testSuite": {
     "nameColumn": "Nombre",
     "dataColumn": "Datos",

--- a/hardpy/hardpy_panel/frontend/public/locales/fr/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/fr/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "Heure de fin",
     "alert": "Alerte"
   },
+  "history": {
+    "title": "Historique des tests",
+    "detailTitle": "Détails de l'exécution",
+    "columns": {
+      "runName": "Nom d'exécution",
+      "startTime": "Heure de début",
+      "result": "Résultat",
+      "serialNumber": "Numéro de série",
+      "details": "Détails"
+    },
+    "viewDetails": "Voir les détails",
+    "selected": "Sélectionné",
+    "unknownRun": "Exécution sans nom",
+    "showMore": "Afficher plus"
+  },
   "testSuite": {
     "nameColumn": "Nom",
     "dataColumn": "Données",

--- a/hardpy/hardpy_panel/frontend/public/locales/ja/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/ja/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "終了時間",
     "alert": "警告"
   },
+  "history": {
+    "title": "テスト履歴",
+    "detailTitle": "テスト実行の詳細",
+    "columns": {
+      "runName": "実行名",
+      "startTime": "開始時刻",
+      "result": "結果",
+      "serialNumber": "シリアル番号",
+      "details": "詳細"
+    },
+    "viewDetails": "詳細を見る",
+    "selected": "選択済み",
+    "unknownRun": "名前なし実行",
+    "showMore": "さらに表示"
+  },
   "testSuite": {
     "nameColumn": "名前",
     "dataColumn": "データ",

--- a/hardpy/hardpy_panel/frontend/public/locales/ru/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/ru/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "Время завершения",
     "alert": "Предупреждение"
   },
+  "history": {
+    "title": "История тестов",
+    "detailTitle": "Детали запуска",
+    "columns": {
+      "runName": "Имя запуска",
+      "startTime": "Время запуска",
+      "result": "Результат",
+      "serialNumber": "Серийный номер",
+      "details": "Детали"
+    },
+    "viewDetails": "Подробнее",
+    "selected": "Выбрано",
+    "unknownRun": "Безымянный запуск",
+    "showMore": "Показать ещё"
+  },
   "testSuite": {
     "nameColumn": "Название",
     "dataColumn": "Данные",

--- a/hardpy/hardpy_panel/frontend/public/locales/zh/translation.json
+++ b/hardpy/hardpy_panel/frontend/public/locales/zh/translation.json
@@ -69,6 +69,21 @@
     "finishTime": "完成时间",
     "alert": "警报"
   },
+  "history": {
+    "title": "测试历史",
+    "detailTitle": "测试运行详情",
+    "columns": {
+      "runName": "运行名称",
+      "startTime": "开始时间",
+      "result": "结果",
+      "serialNumber": "序列号",
+      "details": "详情"
+    },
+    "viewDetails": "查看详情",
+    "selected": "已选择",
+    "unknownRun": "未命名运行",
+    "showMore": "显示更多"
+  },
   "testSuite": {
     "nameColumn": "名称",
     "dataColumn": "数据",

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -215,6 +215,10 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
   let [selectedTests, setSelectedTests] = React.useState<string[]>([]);
   const [selectedHistoryRunId, setSelectedHistoryRunId] =
     React.useState<string | null>(null);
+  const [showHistoryDetails, setShowHistoryDetails] =
+    React.useState<boolean>(false);
+  const [historyDisplayCount, setHistoryDisplayCount] =
+    React.useState<number>(5);
 
   /**
    * Loads HardPy configuration from the backend API on component mount
@@ -715,7 +719,8 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
       })
       .filter((entry) => entry && entry.id !== syncDocumentId)
       .filter((entry): entry is { id: string; name: string; status: string; start_time?: number; serial_number?: string | number } => entry !== null)
-      .sort((a, b) => (b.start_time ?? 0) - (a.start_time ?? 0));
+      .sort((a, b) => (b.start_time ?? 0) - (a.start_time ?? 0))
+      .slice(0, 5);
 
     const selectedHistoryRow = selectedHistoryRunId
       ? (rows.find((row) => row.id === selectedHistoryRunId)?.doc as TestRunI | undefined)
@@ -777,20 +782,33 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
                 <TestHistory
                   history={historyEntries}
                   selectedHistoryId={selectedHistoryRunId}
-                  onSelectHistoryRun={(id) => setSelectedHistoryRunId(id)}
+                  onSelectHistoryRun={(id) => {
+                    setSelectedHistoryRunId(id);
+                    setShowHistoryDetails(true);
+                  }}
                 />
                 {selectedHistoryRow && (
                   <Card style={{ padding: "20px", marginTop: "20px" }}>
-                    <H2>{t("history.detailTitle")}</H2>
-                    <SuiteList
-                      db_state={selectedHistoryRow}
-                      defaultClose={!ultrawide}
-                      selectionSupported={false}
-                      selectedTests={[]}
-                      currentTestConfig={appConfig?.current_test_config}
-                      measurementDisplay={appConfig?.frontend?.measurement_display}
-                      manualCollectMode={manualCollectMode}
-                    />
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                      <H2>{t("history.detailTitle")}</H2>
+                      <Button
+                        minimal
+                        icon={showHistoryDetails ? "chevron-up" : "chevron-down"}
+                        onClick={() => setShowHistoryDetails(!showHistoryDetails)}
+                        title={showHistoryDetails ? "Hide details" : "Show details"}
+                      />
+                    </div>
+                    {showHistoryDetails && (
+                      <SuiteList
+                        db_state={selectedHistoryRow}
+                        defaultClose={!ultrawide}
+                        selectionSupported={false}
+                        selectedTests={[]}
+                        currentTestConfig={appConfig?.current_test_config}
+                        measurementDisplay={appConfig?.frontend?.measurement_display}
+                        manualCollectMode={manualCollectMode}
+                      />
+                    )}
                   </Card>
                 )}
               </div>

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -702,7 +702,7 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
     }
 
     const document_row = rows[index];
-    const historyEntries = rows
+    const filteredRows = rows
       .map((row) => {
         const doc = row.doc as TestRunI | undefined;
         if (!doc || !doc.name || !doc.status) {
@@ -719,8 +719,9 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
       })
       .filter((entry) => entry && entry.id !== syncDocumentId)
       .filter((entry): entry is { id: string; name: string; status: string; start_time?: number; serial_number?: string | number } => entry !== null)
-      .sort((a, b) => (b.start_time ?? 0) - (a.start_time ?? 0))
-      .slice(0, 5);
+      .sort((a, b) => (b.start_time ?? 0) - (a.start_time ?? 0));
+
+    const historyEntries = filteredRows.slice(0, historyDisplayCount);
 
     const selectedHistoryRow = selectedHistoryRunId
       ? (rows.find((row) => row.id === selectedHistoryRunId)?.doc as TestRunI | undefined)
@@ -787,6 +788,16 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
                     setShowHistoryDetails(true);
                   }}
                 />
+                {filteredRows.length > historyDisplayCount && (
+                  <Button
+                    minimal
+                    fill
+                    onClick={() => setHistoryDisplayCount(historyDisplayCount + 5)}
+                    style={{ marginTop: "10px" }}
+                  >
+                    {t("history.showMore")}
+                  </Button>
+                )}
                 {selectedHistoryRow && (
                   <Card style={{ padding: "20px", marginTop: "20px" }}>
                     <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import StartStopButton from "./button/StartStop";
 import { TestRunI } from "./hardpy_test_view/SuiteList";
 import SuiteList from "./hardpy_test_view/SuiteList";
+import TestHistory from "./hardpy_test_view/TestHistory";
 import ProgressView from "./progress/ProgressView";
 import TestStatus from "./hardpy_test_view/TestStatus";
 import ReloadAlert from "./restart_alert/RestartAlert";
@@ -212,6 +213,8 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
   const [previousTestStructure, setPreviousTestStructure] =
     React.useState<string>("");
   let [selectedTests, setSelectedTests] = React.useState<string[]>([]);
+  const [selectedHistoryRunId, setSelectedHistoryRunId] =
+    React.useState<string | null>(null);
 
   /**
    * Loads HardPy configuration from the backend API on component mount
@@ -695,6 +698,27 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
     }
 
     const document_row = rows[index];
+    const historyEntries = rows
+      .map((row) => {
+        const doc = row.doc as TestRunI | undefined;
+        if (!doc || !doc.name || !doc.status) {
+          return null;
+        }
+
+        return {
+          id: row.id,
+          name: doc.name,
+          status: doc.status,
+          start_time: doc.start_time,
+          serial_number: doc.dut?.serial_number,
+        };
+      })
+      .filter((entry): entry is { id: string; name: string; status: string; start_time?: number; serial_number?: string | number } => entry !== null)
+      .sort((a, b) => (b.start_time ?? 0) - (a.start_time ?? 0));
+
+    const selectedHistoryRow = selectedHistoryRunId
+      ? (rows.find((row) => row.id === selectedHistoryRunId)?.doc as TestRunI | undefined)
+      : undefined;
 
     if (!document_row) {
       return (
@@ -714,30 +738,62 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
           style={{ display: "flex", flexDirection: "row" }}
         >
           {(ultrawide || !use_debug_info) && (
-            <Card
+            <div
               style={{
-                flexDirection: "column",
-                padding: "20px",
+                display: "flex",
+                flexDirection: ultrawide ? "row" : "column",
                 flexGrow: 1,
                 flexShrink: 1,
-                marginTop: "20px",
-                marginBottom: "20px",
+                gap: "20px",
               }}
             >
-              <SuiteList
-                db_state={testRunData}
-                defaultClose={!ultrawide}
-                onTestsSelectionChange={handleTestsSelectionChange}
-                selectedTests={selectedTests}
-                selectionSupported={
-                  (appConfig?.frontend?.manual_collect || false) &&
-                  manualCollectMode
-                }
-                currentTestConfig={appConfig?.current_test_config}
-                measurementDisplay={appConfig?.frontend?.measurement_display}
-                manualCollectMode={manualCollectMode}
-              />
-            </Card>
+              <Card
+                style={{
+                  flexDirection: "column",
+                  padding: "20px",
+                  flexGrow: 3,
+                  flexShrink: 1,
+                  marginTop: "20px",
+                  marginBottom: "20px",
+                }}
+              >
+                <SuiteList
+                  db_state={testRunData}
+                  defaultClose={!ultrawide}
+                  onTestsSelectionChange={handleTestsSelectionChange}
+                  selectedTests={selectedTests}
+                  selectionSupported={
+                    (appConfig?.frontend?.manual_collect || false) &&
+                    manualCollectMode
+                  }
+                  currentTestConfig={appConfig?.current_test_config}
+                  measurementDisplay={appConfig?.frontend?.measurement_display}
+                  manualCollectMode={manualCollectMode}
+                />
+              </Card>
+
+              <div style={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
+                <TestHistory
+                  history={historyEntries}
+                  selectedHistoryId={selectedHistoryRunId}
+                  onSelectHistoryRun={(id) => setSelectedHistoryRunId(id)}
+                />
+                {selectedHistoryRow && (
+                  <Card style={{ padding: "20px", marginTop: "20px" }}>
+                    <H2>{t("history.detailTitle")}</H2>
+                    <SuiteList
+                      db_state={selectedHistoryRow}
+                      defaultClose={!ultrawide}
+                      selectionSupported={false}
+                      selectedTests={[]}
+                      currentTestConfig={appConfig?.current_test_config}
+                      measurementDisplay={appConfig?.frontend?.measurement_display}
+                      manualCollectMode={manualCollectMode}
+                    />
+                  </Card>
+                )}
+              </div>
+            </div>
           )}
           {use_debug_info && (
             <Card

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -713,6 +713,7 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
           serial_number: doc.dut?.serial_number,
         };
       })
+      .filter((entry) => entry && entry.id !== syncDocumentId)
       .filter((entry): entry is { id: string; name: string; status: string; start_time?: number; serial_number?: string | number } => entry !== null)
       .sort((a, b) => (b.start_time ?? 0) - (a.start_time ?? 0));
 

--- a/hardpy/hardpy_panel/frontend/src/App.tsx
+++ b/hardpy/hardpy_panel/frontend/src/App.tsx
@@ -53,6 +53,7 @@ interface AppConfig {
     sound_on?: boolean;
     manual_collect?: boolean;
     measurement_display?: boolean;
+    test_history?: boolean;
     modal_result?: {
       enable?: boolean;
       auto_dismiss_pass?: boolean;
@@ -780,47 +781,67 @@ function App({ syncDocumentId }: { syncDocumentId: string }): JSX.Element {
               </Card>
 
               <div style={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
-                <TestHistory
-                  history={historyEntries}
-                  selectedHistoryId={selectedHistoryRunId}
-                  onSelectHistoryRun={(id) => {
-                    setSelectedHistoryRunId(id);
-                    setShowHistoryDetails(true);
-                  }}
-                />
-                {filteredRows.length > historyDisplayCount && (
-                  <Button
-                    minimal
-                    fill
-                    onClick={() => setHistoryDisplayCount(historyDisplayCount + 5)}
-                    style={{ marginTop: "10px" }}
-                  >
-                    {t("history.showMore")}
-                  </Button>
-                )}
-                {selectedHistoryRow && (
-                  <Card style={{ padding: "20px", marginTop: "20px" }}>
-                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                      <H2>{t("history.detailTitle")}</H2>
+                {appConfig?.frontend?.test_history !== false && (
+                  <>
+                    <TestHistory
+                      history={historyEntries}
+                      selectedHistoryId={selectedHistoryRunId}
+                      onSelectHistoryRun={(id) => {
+                        setSelectedHistoryRunId(id);
+                        setShowHistoryDetails(true);
+                      }}
+                    />
+                    {filteredRows.length > historyDisplayCount && (
                       <Button
                         minimal
-                        icon={showHistoryDetails ? "chevron-up" : "chevron-down"}
-                        onClick={() => setShowHistoryDetails(!showHistoryDetails)}
-                        title={showHistoryDetails ? "Hide details" : "Show details"}
-                      />
-                    </div>
-                    {showHistoryDetails && (
-                      <SuiteList
-                        db_state={selectedHistoryRow}
-                        defaultClose={!ultrawide}
-                        selectionSupported={false}
-                        selectedTests={[]}
-                        currentTestConfig={appConfig?.current_test_config}
-                        measurementDisplay={appConfig?.frontend?.measurement_display}
-                        manualCollectMode={manualCollectMode}
-                      />
+                        fill
+                        onClick={() =>
+                          setHistoryDisplayCount(historyDisplayCount + 5)
+                        }
+                        style={{ marginTop: "10px" }}
+                      >
+                        {t("history.showMore")}
+                      </Button>
                     )}
-                  </Card>
+                    {selectedHistoryRow && (
+                      <Card style={{ padding: "20px", marginTop: "20px" }}>
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                          }}
+                        >
+                          <H2>{t("history.detailTitle")}</H2>
+                          <Button
+                            minimal
+                            icon={
+                              showHistoryDetails ? "chevron-up" : "chevron-down"
+                            }
+                            onClick={() =>
+                              setShowHistoryDetails(!showHistoryDetails)
+                            }
+                            title={
+                              showHistoryDetails ? "Hide details" : "Show details"
+                            }
+                          />
+                        </div>
+                        {showHistoryDetails && (
+                          <SuiteList
+                            db_state={selectedHistoryRow}
+                            defaultClose={!ultrawide}
+                            selectionSupported={false}
+                            selectedTests={[]}
+                            currentTestConfig={appConfig?.current_test_config}
+                            measurementDisplay={
+                              appConfig?.frontend?.measurement_display
+                            }
+                            manualCollectMode={manualCollectMode}
+                          />
+                        )}
+                      </Card>
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestHistory.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestHistory.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Everypin
+// GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import * as React from "react";
+import { HTMLTable, Button, Card, H3 } from "@blueprintjs/core";
+import { withTranslation, WithTranslation } from "react-i18next";
+import TestStatus from "./TestStatus";
+import { TestRunI } from "./SuiteList";
+
+export interface HistoryEntry {
+  id: string;
+  name?: string;
+  status?: string;
+  start_time?: number;
+  serial_number?: string | number;
+}
+
+interface Props extends WithTranslation {
+  history: HistoryEntry[];
+  selectedHistoryId: string | null;
+  onSelectHistoryRun: (id: string) => void;
+}
+
+const SECONDS_TO_MILLISECONDS = 1000;
+
+const formatTime = (timestamp?: number): string => {
+  if (!timestamp) {
+    return "-";
+  }
+  return new Date(timestamp * SECONDS_TO_MILLISECONDS).toLocaleString();
+};
+
+const TestHistory: React.FC<Props> = ({
+  t,
+  history,
+  selectedHistoryId,
+  onSelectHistoryRun,
+}) => {
+  if (!history || history.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card style={{ marginTop: "20px" }}>
+      <H3>{t("history.title")}</H3>
+      <HTMLTable bordered condensed striped style={{ width: "100%" }}>
+        <thead>
+          <tr>
+            <th>{t("history.columns.runName")}</th>
+            <th>{t("history.columns.startTime")}</th>
+            <th>{t("history.columns.result")}</th>
+            <th>{t("history.columns.serialNumber")}</th>
+            <th>{t("history.columns.details")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map((entry) => (
+            <tr
+              key={entry.id}
+              style={{
+                background:
+                  selectedHistoryId === entry.id ? "rgba(16, 119, 255, 0.05)" :
+                  "transparent",
+              }}
+            >
+              <td>{entry.name || t("history.unknownRun")}</td>
+              <td>{formatTime(entry.start_time)}</td>
+              <td style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+                <TestStatus status={entry.status || ""} />
+                {entry.status
+                  ? t(`app.status.${entry.status}`) || entry.status
+                  : "-"}
+              </td>
+              <td>{entry.serial_number ?? "-"}</td>
+              <td>
+                <Button
+                  small
+                  minimal
+                  intent={selectedHistoryId === entry.id ? "success" : "primary"}
+                  text={
+                    selectedHistoryId === entry.id
+                      ? t("history.selected")
+                      : t("history.viewDetails")
+                  }
+                  onClick={() => onSelectHistoryRun(entry.id)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </HTMLTable>
+    </Card>
+  );
+};
+
+export default withTranslation()(TestHistory);

--- a/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestHistory.tsx
+++ b/hardpy/hardpy_panel/frontend/src/hardpy_test_view/TestHistory.tsx
@@ -65,11 +65,13 @@ const TestHistory: React.FC<Props> = ({
             >
               <td>{entry.name || t("history.unknownRun")}</td>
               <td>{formatTime(entry.start_time)}</td>
-              <td style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-                <TestStatus status={entry.status || ""} />
-                {entry.status
-                  ? t(`app.status.${entry.status}`) || entry.status
-                  : "-"}
+              <td>
+                <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+                  <TestStatus status={entry.status || ""} />
+                  {entry.status
+                    ? t(`app.status.${entry.status}`) || entry.status
+                    : "-"}
+                </div>
               </td>
               <td>{entry.serial_number ?? "-"}</td>
               <td>

--- a/hardpy/pytest_hardpy/db/couchdb/common.py
+++ b/hardpy/pytest_hardpy/db/couchdb/common.py
@@ -8,10 +8,12 @@ from pycouchdb.exceptions import Conflict
 def update_db(doc: dict, doc_id: str, db: DbServer) -> None:
     """Persist in-memory document to storage backend."""
     try:
-        doc = db.save(doc)
+        saved = db.save(doc)
+        doc["_rev"] = saved["_rev"]
     except Conflict:
         doc["_rev"] = db.get(doc_id)["_rev"]
-        doc = db.save(doc)
+        saved = db.save(doc)
+        doc["_rev"] = saved["_rev"]
 
 def update_doc(doc: dict, doc_id: str, db: DbServer) -> dict:
     """Reload document from storage backend to memory."""

--- a/hardpy/pytest_hardpy/db/couchdb/statestore.py
+++ b/hardpy/pytest_hardpy/db/couchdb/statestore.py
@@ -130,7 +130,7 @@ class CouchDBStateStore(StorageInterface):
         doc.pop("_rev", None)
         try:
             self._db.save(doc)
-        except (GenericError, ConnectionError) as e:
+        except (Conflict, GenericError, ConnectionError) as e:
             self._log.warning(f"Failed to save history: {e}")
 
     def _init_doc(self) -> dict:

--- a/hardpy/pytest_hardpy/db/couchdb/statestore.py
+++ b/hardpy/pytest_hardpy/db/couchdb/statestore.py
@@ -123,6 +123,16 @@ class CouchDBStateStore(StorageInterface):
         """Optimize storage (implementation-specific, may be no-op)."""
         self._db.compact()
 
+    def save_history(self, timestamp_id: str) -> None:
+        """Save current document as a history entry."""
+        doc = self._doc.copy()
+        doc["_id"] = timestamp_id
+        doc.pop("_rev", None)
+        try:
+            self._db.save(doc)
+        except (GenericError, ConnectionError) as e:
+            self._log.warning(f"Failed to save history: {e}")
+
     def _init_doc(self) -> dict:
         """Initialize or load document structure."""
         try:

--- a/hardpy/pytest_hardpy/db/json/statestore.py
+++ b/hardpy/pytest_hardpy/db/json/statestore.py
@@ -108,6 +108,18 @@ class JsonStateStore(StorageInterface):
     def compact(self) -> None:
         """Optimize storage (no-op for JSON file storage)."""
 
+    def save_history(self, timestamp_id: str) -> None:
+        """Save current document as a history entry."""
+        doc = self._doc.copy()
+        doc["_id"] = timestamp_id
+        doc.pop("_rev", None)
+        history_file = self._storage_dir / f"{timestamp_id}.json"
+        try:
+            with history_file.open("w") as f:
+                json.dump(doc, f)
+        except OSError as e:
+            self._log.warning(f"Failed to save history: {e}")
+
     def _init_doc(self) -> dict:
         """Initialize or load document structure."""
         if self._file_path.exists():

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -2,10 +2,10 @@
 # GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from logging import getLogger
 from time import time
-import json
 
 from natsort import natsorted
 from tzlocal import get_localzone

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -2,7 +2,6 @@
 # GNU General Public License v3.0 (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
 
-import json
 from copy import deepcopy
 from logging import getLogger
 from time import time
@@ -92,19 +91,8 @@ class HookReporter(BaseReporter):
 
         # Save to history
         timestamp_id = str(stop_time)
-        doc = self._statestore._doc.copy()
-        doc["_id"] = timestamp_id
-        if "_rev" in doc:
-            del doc["_rev"]
-        try:
-            if isinstance(self._statestore, CouchDBStateStore):
-                self._statestore._db.save(doc)
-            elif isinstance(self._statestore, JsonStateStore):
-                history_file = self._statestore._storage_dir / f"{timestamp_id}.json"
-                with history_file.open("w") as f:
-                    json.dump(doc, f)
-        except Exception as e:
-            self._log.warning(f"Failed to save history: {e}")
+        if isinstance(self._statestore, (CouchDBStateStore, JsonStateStore)):
+            self._statestore.save_history(timestamp_id)
 
     def compact_all(self) -> None:
         """Compact all databases."""

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from copy import deepcopy
 from logging import getLogger
 from time import time
+import json
 
 from natsort import natsorted
 from tzlocal import get_localzone
 
 from hardpy.pytest_hardpy.db import DatabaseField as DF  # noqa: N817
+from hardpy.pytest_hardpy.db.couchdb.statestore import CouchDBStateStore
+from hardpy.pytest_hardpy.db.json.statestore import JsonStateStore
 from hardpy.pytest_hardpy.reporter.base import BaseReporter
 from hardpy.pytest_hardpy.utils import NodeInfo, TestStatus, machine_id
 
@@ -86,6 +89,22 @@ class HookReporter(BaseReporter):
         stop_time = int(time())
         self.set_doc_value(DF.STOP_TIME, stop_time)
         self.set_doc_value(DF.STATUS, status)
+
+        # Save to history
+        timestamp_id = str(int(time()))
+        doc = self._statestore._doc.copy()
+        doc["_id"] = timestamp_id
+        if "_rev" in doc:
+            del doc["_rev"]
+        try:
+            if isinstance(self._statestore, CouchDBStateStore):
+                self._statestore._db.save(doc)
+            elif isinstance(self._statestore, JsonStateStore):
+                history_file = self._statestore._storage_dir / f"{timestamp_id}.json"
+                with history_file.open("w") as f:
+                    json.dump(doc, f)
+        except Exception as e:
+            self._log.warning(f"Failed to save history: {e}")
 
     def compact_all(self) -> None:
         """Compact all databases."""

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -91,7 +91,7 @@ class HookReporter(BaseReporter):
         self.set_doc_value(DF.STATUS, status)
 
         # Save to history
-        timestamp_id = str(int(time()))
+        timestamp_id = str(stop_time)
         doc = self._statestore._doc.copy()
         doc["_id"] = timestamp_id
         if "_rev" in doc:

--- a/hardpy/pytest_hardpy/reporter/hook_reporter.py
+++ b/hardpy/pytest_hardpy/reporter/hook_reporter.py
@@ -90,7 +90,7 @@ class HookReporter(BaseReporter):
         self.set_doc_value(DF.STATUS, status)
 
         # Save to history
-        timestamp_id = str(stop_time)
+        timestamp_id = str(int(time() * 1000))
         if isinstance(self._statestore, (CouchDBStateStore, JsonStateStore)):
             self._statestore.save_history(timestamp_id)
 

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -41,6 +41,7 @@ frontend_default_full_size_button = False
 frontend_default_sound_on = False
 frontend_default_manual_collect = False
 frontend_default_measurement_display = True
+frontend_default_test_history = True
 stand_cloud_default_addr = "standcloud.everypin.io"
 stand_cloud_dafault_connection_only = False
 stand_cloud_default_api_key = ""
@@ -134,6 +135,7 @@ def test_hardpy_config():
     assert config.frontend.sound_on == frontend_default_sound_on
     assert config.frontend.manual_collect == frontend_default_manual_collect
     assert config.frontend.measurement_display == frontend_default_measurement_display
+    assert config.frontend.test_history == frontend_default_test_history
     assert config.stand_cloud.address == stand_cloud_default_addr
     assert config.stand_cloud.connection_only == stand_cloud_dafault_connection_only
     assert config.stand_cloud.api_key == stand_cloud_default_api_key


### PR DESCRIPTION
### Objectives

  Introduce a test history feature that lets operators browse previous test run results directly in the HardPy operator panel — without needing to open CouchDB or inspect JSON files manually.

  ### Changes
  
#### Backend
  - `hardpy/common/config.py` — new test_history: bool = True field in FrontendConfig
  - `hardpy/pytest_hardpy/reporter/hook_reporter.py `— call save_history(timestamp_id) at end of each test run; timestamp derived from stop_time
  - `hardpy/pytest_hardpy/db/couchdb/statestore.py` — CouchDBStateStore.save_history(): saves current doc as a new CouchDB document with timestamp as _id
  - `hardpy/pytest_hardpy/db/json/statestore.py` — JsonStateStore.save_history(): saves current doc as <timestamp>.json in the statestore directory
  - `hardpy/pytest_hardpy/db/couchdb/common.py` — fix _rev not being updated after db.save(), preventing subsequent conflict resolution
  - `hardpy/hardpy_panel/api.py` — GET /api/json_data now reads all *.json files in statestore dir (not just the current doc), returning all history entries

 #### Frontend
  - `App.tsx` — new `TestHistory` component rendered alongside SuiteList; filtered rows exclude current syncDocumentId; Show more button for pagination; feature gated by appConfig.frontend.test_history
  - `TestHistory.tsx` — new component: table of past runs (name, start time, result, serial number) with expandable detail view 
  - Localization strings added for 8 languages (en, cs, de, es, fr, ja, ru, zh)

  #### Tests
  - `tests/test_common/test_config.py` — assert test_history default is True
  
####  Docs
  - `docs/documentation/hardpy_config.md` — document test_history config option
  - `docs/documentation/hardpy_panel.md` — document test history panel feature
  - `docs/about/development.md` — add history translation keys to i18n guide
